### PR TITLE
rfcdiff again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 xml2rfc ?= xml2rfc
 kramdown-rfc2629 ?= kramdown-rfc2629
 idnits ?= idnits
-rfcdiff ?= rfcdiff
+rfcdiff ?= rfcdiff --browse
 
 
 draft := $(basename $(lastword $(sort $(wildcard draft-*.xml)) $(sort $(wildcard draft-*.md))))
@@ -31,8 +31,8 @@ submit: $(next).txt
 idnits: $(next).txt
 	$(idnits) $<
 
-diff:   $(diff_ver).txt
-	$(rfcdiff) --browse $(draft).txt $(diff_ver).txt
+diff:   $(diff_ver).txt $(draft).txt
+	$(rfcdiff) $(draft).txt $(diff_ver).txt
 
 clean:
 	-rm -f $(draft).txt $(draft).html index.html
@@ -47,8 +47,8 @@ endif
 $(next).xml: $(draft).xml
 	sed -e"s/$(basename $<)-latest/$(basename $@)/" $< > $@
 
-$(diff_ver).xml: $(draft).xml $(draft).txt
-	git show $(current):$(draft)$(draft_type) > $(diff_ver)$(draft_type)
+$(diff_ver).xml: $(draft).xml
+	git show $(diff_ver):$(draft)$(draft_type) > $@
 
 .INTERMEDIATE: $(draft).xml
 %.xml: %.md


### PR DESCRIPTION
Think this solves most of the issues. Maybe not happy about all cleanup needed in clean. 

And the -browse argument is probably not a good idea if scripts is using the Makefile? Can we use an env variable to disable that?
