### PR TITLE
Fix sed command to extract Draft Title from XML

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -19,7 +19,7 @@ endif
 	  WG_NAME=$$(echo $< | cut -f 3 -d - -); \
 	  DRAFT_STATUS=$$(test "$$AUTHOR_LABEL" = ietf && echo Working Group || echo Individual); \
 	  GITHUB_USER=$(GITHUB_USER); GITHUB_REPO=$(GITHUB_REPO); \
-	  DRAFT_TITLE=$$(sed -e '/<title[^>]*>[^<]*$$/{s/.*>//g;H};/<\/title>/{H;x;s/.*<title/</g;s/<[^>]*>//g;q};d' $<); \
+	  DRAFT_TITLE=$$(sed -e '/<title[^>]*>[^<]*$$/{s/.*>//g;H;};/<\/title>/{H;x;s/.*<title/</g;s/<[^>]*>//g;q;};d' $<); \
 	  sed -i~ $(foreach label,DRAFT_NAME DRAFT_TITLE DRAFT_STATUS GITHUB_USER GITHUB_REPO WG_NAME,-e 's~{$(label)}~'"$$$(label)"'~g') $(filter %.md,$(TEMPLATE_FILES))
 	git add $(TEMPLATE_FILES)
 ifneq (xml,$(firstword $(draft_types)))


### PR DESCRIPTION
This was failing for me on Mac OS X and I tracked it down to these missing semicolons.

At http://sed.sourceforge.net/sedfaq.html I found this: "Following an address or address range, sed accepts curly braces '{...}' so several commands may be applied to that line or to the lines matched by the address range. On the command line, semicolons ';' separate each instruction and must precede the closing brace."