### PR TITLE
Adding Julian Reschke's xslt as an option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 *.swp
 lib
+rfc2629xslt
+*.xslt
 .template-files.mk
 draft-*

--- a/addstyle.sed
+++ b/addstyle.sed
@@ -1,7 +1,26 @@
-\~</style>~ { a\
-  <style type="text/css">/*<![CDATA[*/
-  r lib/style.css
-  a\
+/<style[^>]*>/,/<\/style>/{
+  /<style[^>]*>/{
+    h
+    s/<style[^>]*>.*//
+    p
+    i\
+<style type="text/css">/*<![CDATA[*/
+    # Unfortunately, r appends after the current line.  If the end of the style
+    # pattern is on this line, then this will mean that the end of the line
+    # will appear before the style.  That's terrible.  See below.
+    r lib/style.css
+    a\
   /*]]>*/</style>
+    g
+  }
+  # Save the last line for later.
+  /<\/style>/h
+  d
 }
-\~<style ~,\~</style>~d
+# This recovers a saved line and prints it.
+x
+/<\/style>/{
+  s/.*<\/style>//
+  p
+}
+x

--- a/config.mk
+++ b/config.mk
@@ -17,6 +17,10 @@ mmark ?= mmark
 #   https://github.com/Juniper/libslax/tree/master/doc/oxtradoc
 oxtradoc ?= oxtradoc.in
 
+# When using rfc2629.xslt extensions:
+#   https://greenbytes.de/tech/webdav/rfc2629xslt.html
+xsltproc ?= xsltproc
+
 # For sanity checkout your draft:
 #   https://tools.ietf.org/tools/idnits/
 idnits ?= idnits

--- a/main.mk
+++ b/main.mk
@@ -63,7 +63,7 @@ $(XSLTDIR)/clean-for-DTD.xslt $(XSLTDIR)/rfc2629.xslt: $(XSLTDIR)
 $(XSLTDIR):
 	git clone --depth 10 -b master https://github.com/reschke/xml2rfc $@
 
-%.cleanxml: %.xml $(LIBDIR)/clean-for-DTD.xslt
+%.cleanxml: %.xml $(LIBDIR)/clean-for-DTD.xslt $(LIBDIR)/rfc2629.xslt
 	$(xsltproc) --novalid $(LIBDIR)/clean-for-DTD.xslt $< > $@
 
 %.htmltmp: %.cleanxml $(LIBDIR)/rfc2629.xslt

--- a/style.css
+++ b/style.css
@@ -63,7 +63,11 @@ ul.toc li {
   padding-bottom: 5px;
   margin: 0;
 }
-ul.toc, ul.toc ul {
+ul.toc ul {
+  margin: 0;
+}
+/* xml2rfc nests ul directly inside ul which messes with the style badly */
+ul.toc, ul.toc>ul, ul.toc ul>ul {
   margin: 0 0 0 1.5em;
 }
 
@@ -197,6 +201,9 @@ ol, ul, li, p {
 }
 li, p {
   margin-left: 0;
+}
+address {
+  font-style: normal;
 }
 
 .github-fork-ribbon-wrapper {


### PR DESCRIPTION
@reschke, can you test that this works for you?

Test this by putting `USE_XSLT:=1` in your Makefile.  If you have CI setup, then you also have to modify circle.yml/.travis.yml to include the install for xsltproc (unless you don't need that on those machines, I haven't checked).

TODO: Modify setup.mk to accept USE_XSLT=1 and then automatically modify those files as needed.

Note: still reluctant to make this a default since it requires more software; it will definitely be slower.