### PR TITLE
rfcdiff takes &, not ^

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -4,7 +4,7 @@ This is the working area for the {DRAFT_STATUS} internet-draft, "{DRAFT_TITLE}".
 
 * [Editor's copy](https://{GITHUB_USER}.github.io/{GITHUB_REPO}/)
 * [{DRAFT_STATUS} Draft] (https://tools.ietf.org/html/{DRAFT_NAME})
-* [Compare {DRAFT_STATUS} Draft and Editor's copy] (https://tools.ietf.org/rfcdiff?url1=https://tools.ietf.org/id/{DRAFT_NAME}.txt^url2=https://{GITHUB_USER}.github.io/{GITHUB_REPO}/{DRAFT_NAME}.txt)
+* [Compare {DRAFT_STATUS} Draft and Editor's copy] (https://tools.ietf.org/rfcdiff?url1=https://tools.ietf.org/id/{DRAFT_NAME}.txt&url2=https://{GITHUB_USER}.github.io/{GITHUB_REPO}/{DRAFT_NAME}.txt)
 
 
 ## Building the Draft


### PR DESCRIPTION
Found this while incorporating it on QUIC's page