### PR TITLE
Adding -w flag to diff -- ignore whitespace

### DIFF
--- a/update.mk
+++ b/update.mk
@@ -27,7 +27,7 @@ auto_update:
 update:
 	git -C $(LIBDIR) pull
 	@for i in Makefile .travis.yml circle.yml; do \
-	  diff -q $$i $(LIBDIR)/template/$$i >/dev/null || \
+	  diff -qw $$i $(LIBDIR)/template/$$i >/dev/null || \
 	    echo $$i is out of date, run '``'cp -f $(LIBDIR)/template/$$i $$i"''" to update.; \
 	done
 


### PR DESCRIPTION
Suppresses instructions to update files from template when only difference is whitespace (e.g. different EOL characters).