### PR TITLE
Check for different filesystems with --local

### DIFF
--- a/ghpages.mk
+++ b/ghpages.mk
@@ -46,14 +46,14 @@ endif
 fetch-ghpages:
 	-git fetch -q $(FETCH_SHALLOW) origin gh-pages:gh-pages
 
-GHPAGES_TMP := /tmp/ghpages$(shell echo $$$$)
 ifeq (true,$(CI))
 CLONE_LOCAL :=
-else ifeq($(shell stat . -c %d),$(shell stat $(GHPAGES_TMP) -c %d))
-CLONE_LOCAL :=
-else
+else ifeq ($(shell stat . -c %d),$(shell stat /tmp -c %d))
 CLONE_LOCAL := --local
+else
+CLONE_LOCAL := --local --no-hardlink
 endif
+GHPAGES_TMP := /tmp/ghpages$(shell echo $$$$)
 ghpages: $(GHPAGES_TMP)
 .INTERMEDIATE: $(GHPAGES_TMP)
 $(GHPAGES_TMP): fetch-ghpages

--- a/ghpages.mk
+++ b/ghpages.mk
@@ -46,12 +46,14 @@ endif
 fetch-ghpages:
 	-git fetch -q $(FETCH_SHALLOW) origin gh-pages:gh-pages
 
+GHPAGES_TMP := /tmp/ghpages$(shell echo $$$$)
 ifeq (true,$(CI))
+CLONE_LOCAL :=
+else ifeq($(shell stat . -c %d),$(shell stat $(GHPAGES_TMP) -c %d))
 CLONE_LOCAL :=
 else
 CLONE_LOCAL := --local
 endif
-GHPAGES_TMP := /tmp/ghpages$(shell echo $$$$)
 ghpages: $(GHPAGES_TMP)
 .INTERMEDIATE: $(GHPAGES_TMP)
 $(GHPAGES_TMP): fetch-ghpages


### PR DESCRIPTION
Adds an extra branch -- if local, but on different filesystems, use the --no-hardlink option in CLONE_LOCAL.  Otherwise, `make ghpages` fails with an error about cross-device links.