### PR TITLE
Use git hooks to prevent committing anything that won't make

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-# Force *.sed files to use LF for EOL -- CRLF breaks
+# Force *.sed and *.sh files to use LF for EOL -- CRLF breaks
 *.sed text eol=lf
+*.sh text eol=lf

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+
+exec 1>&2
+
 # No tests to update gh-pages
-BRANCH=$(git symbolic-ref HEAD 2>/dev/null)
-[ $BRANCH = "refs/heads/gh-pages" ] && exit 0
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+[ "$BRANCH" = "gh-pages" ] && exit 0
 
 git stash save -k -q
 make
@@ -14,5 +17,3 @@ then
   echo "To commit anyway, run \"git commit --no-verify\""
   exit 1
 fi
-
-exit 0

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# No tests to update gh-pages
+BRANCH=$(git symbolic-ref HEAD 2>/dev/null)
+[ $BRANCH = "refs/heads/gh-pages" ] && exit 0
+
 git stash save -k -q
 make
 RESULT=$?

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -7,5 +7,12 @@ git stash save -k -q
 make
 RESULT=$?
 git stash pop -q
-[ $RESULT -ne 0 ] && exit 1
+
+if [ $RESULT -ne 0 ]
+then
+  echo "Commit refused -- documents don't build successfully."
+  echo "To commit anyway, run \"git commit --no-verify\""
+  exit 1
+fi
+
 exit 0

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git stash save -q --keep-index
+git stash save -k -q
 make
 RESULT=$?
 git stash pop -q

--- a/setup.mk
+++ b/setup.mk
@@ -36,7 +36,8 @@ endif
 TEMPLATE_FILES := \
   Makefile .gitignore \
   README.md CONTRIBUTING.md \
-  .travis.yml circle.yml
+  .travis.yml circle.yml \
+	pre-commit.sh
 
 MARKDOWN_FILES := $(filter %.md,$(TEMPLATE_FILES))
 
@@ -67,6 +68,11 @@ setup-circle: circle.yml
 	@-rm -f $<~
 	git add $<
 endif # USE_XSLT
+
+.PHONY: setup-hook
+setup-hook: pre-commit.sh
+  git add $<
+  ln -s ../../pre-commit.sh .git/hooks/pre-commit
 
 .PHONY: setup-gitignore
 setup-gitignore: .gitignore

--- a/setup.mk
+++ b/setup.mk
@@ -36,8 +36,7 @@ endif
 TEMPLATE_FILES := \
   Makefile .gitignore \
   README.md CONTRIBUTING.md \
-  .travis.yml circle.yml \
-	pre-commit.sh
+  .travis.yml circle.yml
 
 MARKDOWN_FILES := $(filter %.md,$(TEMPLATE_FILES))
 
@@ -69,11 +68,6 @@ setup-circle: circle.yml
 	git add $<
 endif # USE_XSLT
 
-.PHONY: setup-hook
-setup-hook: pre-commit.sh
-  git add $<
-  ln -s ../../pre-commit.sh .git/hooks/pre-commit
-
 .PHONY: setup-gitignore
 setup-gitignore: .gitignore
 ifndef SUBMODULE
@@ -98,6 +92,7 @@ setup-markdown: $(firstword $(drafts)).xml $(MARKDOWN_FILES)
 .PHONY: setup-master
 setup-master: setup-files setup-markdown setup-gitignore
 	git commit -m "Setup repository for $(firstword $(drafts))"
+	-ln -s ../../lib/pre-commit.sh .git/hooks/pre-commit
 
 # Check if the gh-pages branch already exists either remotely or locally
 GHPAGES_COMMITS := $(shell git show-ref -s gh-pages 2>/dev/null)

--- a/template/pre-commit.sh
+++ b/template/pre-commit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+git stash save -q --keep-index
+make
+RESULT=$?
+git stash pop -q
+[ $RESULT -ne 0 ] && exit 1
+exit 0

--- a/update.mk
+++ b/update.mk
@@ -30,6 +30,6 @@ update:
 	  [ -z "$(comm -13 $$i $(LIBDIR)/template/$$i)" ] || \
 	    echo $$i is out of date, check against $(LIBDIR)/template/$$i for changes.; \
 	done
-	@[ -L .git/hooks/pre-commit ] || ln -s ../../lib/pre-commit.sh .git/hooks/pre-commit; \
+	@[ -L .git/hooks/pre-commit ] || ln -s ../../lib/pre-commit.sh .git/hooks/pre-commit
 
 endif # CI

--- a/update.mk
+++ b/update.mk
@@ -30,5 +30,6 @@ update:
 	  [ -z "$(comm -13 $$i $(LIBDIR)/template/$$i)" ] || \
 	    echo $$i is out of date, check against $(LIBDIR)/template/$$i for changes.; \
 	done
+	@[ -L .git/hooks/pre-commit ] || ln -s ../../lib/pre-commit.sh .git/hooks/pre-commit; \
 
 endif # CI

--- a/update.mk
+++ b/update.mk
@@ -26,9 +26,11 @@ auto_update:
 .PHONY: update
 update:
 	git -C $(LIBDIR) pull
-	@for i in Makefile .travis.yml circle.yml; do \
-	  [ -z "$(comm -13 $$i $(LIBDIR)/template/$$i)" ] || \
-	    echo $$i is out of date, check against $(LIBDIR)/template/$$i for changes.; \
+	@for i in Makefile .travis.yml circle.yml pre-commit.sh; do \
+    [ -e $$i ] || echo $$i is missing, please copy from $(LIBDIR)/template/$$i.; \
+		[ -z "$(comm -13 $$i $(LIBDIR)/template/$$i)" ] || \
+			echo $$i is out of date, check against $(LIBDIR)/template/$$i for changes.; \
 	done
+	@[ -L .git/hooks/pre-commit ] || ln -s ../../pre-commit.sh .git/hooks/pre-commit
 
 endif # CI

--- a/update.mk
+++ b/update.mk
@@ -26,11 +26,9 @@ auto_update:
 .PHONY: update
 update:
 	git -C $(LIBDIR) pull
-	@for i in Makefile .travis.yml circle.yml pre-commit.sh; do \
-    [ -e $$i ] || echo $$i is missing, please copy from $(LIBDIR)/template/$$i.; \
-		[ -z "$(comm -13 $$i $(LIBDIR)/template/$$i)" ] || \
-			echo $$i is out of date, check against $(LIBDIR)/template/$$i for changes.; \
+	@for i in Makefile .travis.yml circle.yml; do \
+	  [ -z "$(comm -13 $$i $(LIBDIR)/template/$$i)" ] || \
+	    echo $$i is out of date, check against $(LIBDIR)/template/$$i for changes.; \
 	done
-	@[ -L .git/hooks/pre-commit ] || ln -s ../../pre-commit.sh .git/hooks/pre-commit
 
 endif # CI


### PR DESCRIPTION
Building on your Makefile-reject of whitespace in QUIC, this uses git client hooks to check that a commit *will* make successfully before allowing you to commit.  (You can always bypass with `git commit --no-verify`, of course, and it tells you that if it fails.)

It took a few twists before I got it working for both setup and existing repos, so feel free to squash it together.  I think this should be in good shape now, but please bang on it a little.