### PR TITLE
Prune expired artifacts from gh-pages

### DIFF
--- a/ghpages.mk
+++ b/ghpages.mk
@@ -37,17 +37,9 @@ else
 	@echo '</html>' >>$@
 endif
 
-# Can't do a shallow fetch for master; need history to check ages
-ifeq (true,$(CI))
-ifneq (master,$(SOURCE_BRANCH))
-FETCH_SHALLOW := --depth=5
-endif
-endif
-FETCH_SHALLOW ?=
-
 .PHONY: fetch-ghpages
 fetch-ghpages:
-	-git fetch -q $(FETCH_SHALLOW) origin gh-pages:gh-pages
+	-git fetch -q origin gh-pages:gh-pages
 
 ifeq (true,$(CI))
 CLONE_LOCAL :=

--- a/ghpages.mk
+++ b/ghpages.mk
@@ -78,8 +78,8 @@ else
 endif
 ifeq (true,$(PUSH_GHPAGES))
 
-	-@for branch in `git remote`; do \
-		git remote prune $$branch; \
+	-@for remote in `git remote`; do \
+		git remote prune $$remote; \
 	done;
 
 # Clean up obsolete directories

--- a/ghpages.mk
+++ b/ghpages.mk
@@ -71,6 +71,7 @@ PUBLISHED := index.html $(drafts_html) $(drafts_txt)
 .PHONY: ghpages gh-pages
 gh-pages: ghpages
 ghpages: $(PUBLISHED)
+
 ifneq (true,$(CI))
 	@git show-ref refs/heads/gh-pages >/dev/null 2>&1 || \
 	  (git show-ref refs/remotes/origin/gh-pages >/dev/null 2>&1 && \
@@ -84,6 +85,9 @@ ifeq (true,$(PUSH_GHPAGES))
 ifneq (,$(TARGET_DIR))
 	mkdir -p $(GHPAGES_TMP)/$(TARGET_DIR)
 endif
+	@EXCESS_FILES="$(addprefix $(TARGET_DIR),$(filter-out $^,$(notdir $(foreach ext,*.html *.txt,$(wildcard $(GHPAGES_TMP)/$(TARGET_DIR)/$(ext))))))"; \
+	[ -n "$$EXCESS_FILES" ] && git -C $(GHPAGES_TMP) rm -f --ignore-unmatch -- $$EXCESS_FILES
+
 	cp -f $(filter-out $(GHPAGES_TMP),$^) $(GHPAGES_TMP)/$(TARGET_DIR)
 	git -C $(GHPAGES_TMP) add -f $(addprefix $(TARGET_DIR),$(filter-out $(GHPAGES_TMP),$^))
 	if test `git -C $(GHPAGES_TMP) status --porcelain | grep '^[A-Z]' | wc -l` -gt 0; then \

--- a/ghpages.mk
+++ b/ghpages.mk
@@ -110,7 +110,7 @@ ifneq (0,$(words $(OBSOLETE_DIRECTORIES)))
 	for item in $(OBSOLETE_DIRECTORIES); do \
 		if [ -d "$(GHPAGES_TMP)/$$item" ] && \
 			[ "`git -C $(GHPAGES_TMP) log -r -t -n 1 --format=%ct $$item`" -lt "$$CUTOFF" ]; \
-			then git -C $(GHPAGES_TMP) rm -f -r -n $$item; \
+			then git -C $(GHPAGES_TMP) rm -f -r $$item; \
 		fi \
 	done;
 endif


### PR DESCRIPTION
Fixes #68.  Two key cleanup actions:

- When building any branch, if a draft no longer exists in that branch, remove it from that branch's directory.  This makes renames take effect, rather than leaving [old copies of documents](https://quicwg.github.io/base-drafts/draft-ietf-quic-http-mapping.html) that might confuse someone.
- When building master, do an extra check for [deleted branches](https://quicwg.github.io/base-drafts/http-name/).  Remove them when:
    - They no longer exist on any remote (which will only be origin for CI)
    - The documents were last built more than 30 days ago

I would have made the second one "the branch was deleted more than 30 days ago," but it appears that once a branch is deleted, git retains no record that it ever existed.  Please pay particular attention to line 109; I think I read somewhere that `date` has different parameters on Mac, so this line may also need to be variable based on the system, but I don't know what that format is.