### PR TITLE
Don't run make during conflict resolution

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -4,7 +4,10 @@ exec 1>&2
 
 # No tests to update gh-pages
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
-[ "$BRANCH" = "gh-pages" ] && exit 0
+if [ "$BRANCH" = "gh-pages" ] ||
+   [ -e .git/MERGE_HEAD ]; then
+     exit 0
+fi
 
 git stash save -k -q
 make


### PR DESCRIPTION
I've had a couple instances where the pre-commit script apparently blew away my .git/MERGE_HEAD and git was very confused when I tried to commit the merged version.  For now, at least, I've updated the script to simply ignore merge commits just like it ignores gh-pages.