### PR TITLE
Cache env variable isn't defined when this section is parsed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - gem install --no-doc kramdown-rfc2629
     - go get "$mmark_src" && go build "$mmark_src"
   cache_directories:
-    - "${HOME}/${CIRCLE_PROJECT_REPONAME}/.refcache"
+    - .refcache
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - gem install --no-doc kramdown-rfc2629
     - go get "$mmark_src" && go build "$mmark_src"
   cache_directories:
-    - "${KRAMDOWN_REFCACHEDIR}"
+    - "${HOME}/${CIRCLE_PROJECT_REPONAME}/.refcache"
 
 test:
   override:


### PR DESCRIPTION
Your last commit is generating a warning on Circle that the requested cache directory doesn't exist.  I *think* this fixes it.