### PR TITLE
Fewer assumptions

### DIFF
--- a/id.mk
+++ b/id.mk
@@ -53,10 +53,10 @@ endif
 endif
 CI_ARTIFACTS := $(CIRCLE_ARTIFACTS)
 
-ifeq (,$(shell git config --get user.name))
+ifeq (,$(shell git config --global --get user.name))
 CI_AUTHOR = -c user.name="ID Bot"
 endif
-ifeq (,$(shell git config --get user.email))
+ifeq (,$(shell git config --global --get user.email))
 CI_AUTHOR += -c user.email="idbot@example.com"
 endif
 

--- a/tests/steps/repo_setup.py
+++ b/tests/steps/repo_setup.py
@@ -26,6 +26,8 @@ def step_impl(context):
         call(["git", "init"])
     with cd(context.working_dir):
         call(["git", "clone", context.origin_dir, "."])
+        call(["git", "config", "user.name", "Behave Tests"])
+        call(["git", "config", "user.email", "behave@example.com"])
 
 
 @given(u'a git repo with no origin')
@@ -34,6 +36,8 @@ def step_impl(context):
     context.working_dir = mkdtemp()
     with cd(context.working_dir):
         call(["git", "init"])
+        call(["git", "config", "user.name", "Behave Tests"])
+        call(["git", "config", "user.email", "behave@example.com"])
 
 
 @given(u'lib is cloned in')
@@ -53,8 +57,7 @@ def step_impl(context):
             call(["sed", "-e", "s/draft-hartke-xmpp-stupid/{}/".format(draft_name),
                   "lib/doc/example.md"], stdout=newFile)
         call(["git", "add", file_name])
-        call(["git", "-c", "user.name=Behave Tests", "-c", "user.email=behave@example.com",
-              "commit", "-am", "Initial commit of {}".format(draft_name)])
+        call(["git", "commit", "-am", "Initial commit of {}".format(draft_name)])
 
 
 @given(u'a git repo with a single Kramdown draft')


### PR DESCRIPTION
The current code avoids setting CI_AUTHOR when the user/e-mail config is repo-local.  As a result, commits later fail in the repos cloned to /tmp.  This is why setting the config in the local repo caused the tests to start failing.  I assume we both have these configured globally on our local machines, so we've never hit this bug ourselves.