### PR TITLE
Only stash (and apply) if there are uncommitted changes

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -11,7 +11,7 @@ if [ "$BRANCH" = "gh-pages" ] ||
 fi
 
 STASHED=0
-if test `git status --porcelain | grep '^[A-Z]' | wc -l` -gt 0; then
+if [ `git status --porcelain | grep '^[A-Z]' | wc -l` -gt 0 ]; then
   git stash save -k -q
   STASHED=1
 fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -5,14 +5,23 @@ exec 1>&2
 # No tests to update gh-pages
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 if [ "$BRANCH" = "gh-pages" ] ||
+   [ "$BRANCH" = "gh-issues" ] ||
    [ -e .git/MERGE_HEAD ]; then
      exit 0
 fi
 
-git stash save -k -q
+STASHED=0
+if test `git status --porcelain | grep '^[A-Z]' | wc -l` -gt 0; then
+  git stash save -k -q
+  STASHED=1
+fi
+
 make
 RESULT=$?
-git stash pop -q
+
+if test $STASHED -ne 0; then
+  git stash pop -q
+fi
 
 if [ $RESULT -ne 0 ]
 then


### PR DESCRIPTION
I noticed some odd artifacts of an attempted stash application after committing, and realized that there's a bug in the following situation:

- You commit with nothing in your working directory (so `git stash` doesn't create a new stash)
- You have old stashes that are still hanging around (so `git stash pop` *does* apply a stash)

This checks whether there are unstaged changes and only runs the stash/apply if there were.