### PR TITLE
Shallow clones break gh-pages pruning

### DIFF
--- a/template/circle.yml
+++ b/template/circle.yml
@@ -6,7 +6,8 @@ machine:
 
 checkout:
   post:
-    - git fetch origin gh-pages --depth 10
+    - if [ -e .git/shallow ]; then git fetch origin --unshallow; fi
+    - git fetch origin gh-pages
 
 dependencies:
   pre:


### PR DESCRIPTION
Figured out why Circle wasn't cleaning up old branches still, even though running locally does.  The template circle.yml file does a shallow fetch, so Circle never has a full history of gh-pages.  That causes all files to appear to have been created a day or so ago by the oldest commit in its clone.

This .yml change, which I've added to QUIC already, will unshallow the repo if it's shallow, so that history is available.  This shouldn't decrease perf noticeably, as Circle caches the repo between builds and won't need to re-fetch the whole history every time.