### PR TITLE
Circle cache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,9 @@ dependencies:
     - pip install xml2rfc behave
     - gem install --no-doc kramdown-rfc2629
     - go get "$mmark_src" && go build "$mmark_src"
+  cache_directories:
+    - "~/.cache"
+    - "/opt/circleci/.rvm/gems"
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,6 @@ dependencies:
     - gem install --no-doc kramdown-rfc2629
     - go get "$mmark_src" && go build "$mmark_src"
   cache_directories:
-    - "~/.cache"
     - "/opt/circleci/.rvm/gems"
 
 test:

--- a/template/circle.yml
+++ b/template/circle.yml
@@ -14,6 +14,9 @@ dependencies:
     - pip install xml2rfc
     - if head -1 -q *.md | grep '^\-\-\-' >/dev/null 2>&1; then gem install --no-doc kramdown-rfc2629; fi
     - if head -1 -q *.md | grep '^%%%' >/dev/null 2>&1; then go get "$mmark_src" && go build "$mmark_src"; fi
+  cache_directories:
+    - "~/.cache"
+    - "/opt/circleci/.rvm/gems"
 
 test:
   override:

--- a/template/circle.yml
+++ b/template/circle.yml
@@ -3,6 +3,9 @@ machine:
     GOPATH: "${HOME}/${CIRCLE_PROJECT_REPONAME}/.go_workspace"
     mmark_src: github.com/miekg/mmark/mmark
     mmark: ./mmark
+  python:
+    version: 3.5.2
+
 
 checkout:
   post:

--- a/template/circle.yml
+++ b/template/circle.yml
@@ -18,7 +18,6 @@ dependencies:
     - if head -1 -q *.md | grep '^\-\-\-' >/dev/null 2>&1; then gem install --no-doc kramdown-rfc2629; fi
     - if head -1 -q *.md | grep '^%%%' >/dev/null 2>&1; then go get "$mmark_src" && go build "$mmark_src"; fi
   cache_directories:
-    - "~/.cache"
     - "/opt/circleci/.rvm/gems"
 
 test:


### PR DESCRIPTION
This caches gem's download directory, and declaring that you use Python actually preinstalls xml2rfc and behave, so those commands become no-ops.  (We could remove them, but it might be nice to leave the dependency explicit.)