### PR TITLE
Fix preprocessing when kramdown-rfc2629 is used.

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -32,8 +32,8 @@ export XML_RESOURCE_ORG_PREFIX
 %.xml: %.md
 	@h=$$(head -1 $< | cut -c 1-3 -); \
 	if [ "$$h" = '---' ]; then \
-	  echo '$(subst ','"'"',cat $< $(MD_PREPROCESSOR) $(REMOVE_LATEST) | $(kramdown-rfc2629) $< > $@)'; \
-	  cat $< $(MD_PREPROCESSOR) $(REMOVE_LATEST) | $(kramdown-rfc2629) $< > $@; \
+	  echo '$(subst ','"'"',cat $< $(MD_PREPROCESSOR) $(REMOVE_LATEST) | $(kramdown-rfc2629) > $@)'; \
+	  cat $< $(MD_PREPROCESSOR) $(REMOVE_LATEST) | $(kramdown-rfc2629) > $@; \
 	elif [ "$$h" = '%%%' ]; then \
 	  echo '$(subst ','"'"',cat $< $(MD_PREPROCESSOR) $(REMOVE_LATEST) | $(mmark) -xml2 -page > $@)'; \
 	  cat $< $(MD_PREPROCESSOR) $(REMOVE_LATEST) | $(mmark) -xml2 -page > $@; \


### PR DESCRIPTION
This fixes a bug introduced in commit
5b6bdb3697b9c65599de845eb1302df4e16f59c5
in which the preprocessor was run but kramdown-2629 actually read
input from the .md file not from stdin, which meant that the
preprocessed .md file was ignored.