### PR TITLE
Support SHORTNAME_PREFIX for gh-pages

### DIFF
--- a/ghpages.mk
+++ b/ghpages.mk
@@ -65,7 +65,18 @@ GHPAGES_INSTALLED := $(addprefix $(GHPAGES_TARGET)/,$(GHPAGES_PUBLISHED))
 $(GHPAGES_INSTALLED): $(GHPAGES_PUBLISHED) $(GHPAGES_TARGET)
 	cp -f $(notdir $@) $@
 
-GHPAGES_ALL := $(GHPAGES_INSTALLED) $(GHPAGES_TARGET)/index.html
+ifneq (,$(SHORTNAME_PREFIX))
+define shortname_rule =
+$(dir $(1))$(subst $(SHORTNAME_PREFIX),,$(notdir $(1))): $(1)
+	rm -f $(dir $(1))$(subst $(SHORTNAME_PREFIX),,$(notdir $(1)))
+	ln -s $(notdir $(1)) $(dir $(1))$(subst $(SHORTNAME_PREFIX),,$(notdir $(1)))
+endef
+
+GHPAGES_LINKED := $(subst $(SHORTNAME_PREFIX),,$(GHPAGES_INSTALLED))
+$(foreach _file,$(GHPAGES_INSTALLED),$(eval $(call shortname_rule,$(_file))))
+endif
+
+GHPAGES_ALL := $(GHPAGES_INSTALLED) $(GHPAGES_TARGET)/index.html $(GHPAGES_LINKED)
 $(GHPAGES_TARGET)/index.html: $(GHPAGES_INSTALLED)
 	$(LIBDIR)/build-index.sh "$(dir $@)" "$(GITHUB_USER)" "$(GITHUB_REPO)" >$@
 

--- a/ghpages.mk
+++ b/ghpages.mk
@@ -68,8 +68,8 @@ $(GHPAGES_INSTALLED): $(GHPAGES_PUBLISHED) $(GHPAGES_TARGET)
 ifneq (,$(SHORTNAME_PREFIX))
 define shortname_rule =
 $(dir $(1))$(subst $(SHORTNAME_PREFIX),,$(notdir $(1))): $(1)
-	rm -f $(dir $(1))$(subst $(SHORTNAME_PREFIX),,$(notdir $(1)))
-	ln -s $(notdir $(1)) $(dir $(1))$(subst $(SHORTNAME_PREFIX),,$(notdir $(1)))
+	rm -f $$@
+	ln -s $$< $$@
 endef
 
 GHPAGES_LINKED := $(subst $(SHORTNAME_PREFIX),,$(GHPAGES_INSTALLED))


### PR DESCRIPTION
Admittedly a vanity rule to avoid breaking Mark's existing links, but this enables the creation of shortened names in gh-pages.  I can understand if some people don't want to type `draft-me-them-` all the time....