### PR TITLE
Modularize gh-pages

### DIFF
--- a/ghpages.mk
+++ b/ghpages.mk
@@ -99,10 +99,14 @@ cleanup-ghpages: $(GHPAGES_ROOT)
 	fi
 
 
-.PHONY: ghpages gh-pages
+.PHONY: ghpages gh-pages stage-ghpages commit-ghpages
 gh-pages: ghpages
-ghpages: cleanup-ghpages $(GHPAGES_ALL)
+ghpages: cleanup-ghpages commit-ghpages
+
+stage-ghpages: $(GHPAGES_ALL)
 	git -C $(GHPAGES_ROOT) add -f $(GHPAGES_ALL)
+
+commit-ghpages: stage-ghpages
 	if test `git -C $(GHPAGES_ROOT) status --porcelain | grep '^[A-Z]' | wc -l` -gt 0; then \
 	  git -C $(GHPAGES_ROOT) $(CI_AUTHOR) commit -m "Script updating gh-pages from $(shell git rev-parse --short HEAD). [ci skip]"; fi
 ifeq (true,$(PUSH_GHPAGES))


### PR DESCRIPTION
No functional change to the template (if I did it right!), but by having multiple gh-pages targets, a parent repo's Makefile can hook in and add additional functionality to gh-pages, like this:

```
ghpages: link-ghpages
commit-ghpages: | link-ghpages

link-ghpages: stage-ghpages
	@for file in $(GHPAGES_TARGET)/draft-ietf-httpbis-*.html \
					 $(GHPAGES_TARGET)/draft-ietf-httpbis-*.txt; do \
		newfilename=`echo $$file | sed -e 's/draft-ietf-httpbis-//'`; \
		ln -sf `basename $$file` $$newfilename; \
		git -C $(GHPAGES_ROOT) add `realpath --relative-to=$(GHPAGES_ROOT) $$newfilename`; \
	done;
```

Closes #119, since this is a better solution.