### PR TITLE
Don't use git submodule

### DIFF
--- a/id.mk
+++ b/id.mk
@@ -1,7 +1,9 @@
 ## Identify drafts, types and versions
 
-ifneq (,$(shell git submodule status $(LIBDIR) 2>/dev/null))
+ifneq (,$(wildcard .gitmodules))
+ifneq (,$(shell grep "path = $(LIBDIR)" .gitmodules))
 SUBMODULE = true
+endif
 endif
 
 drafts := $(sort $(basename $(wildcard $(foreach pattern,? *-[-a-z]? *-?[a-z] *[a-z0-9]??,$(foreach ext,xml org md,draft-$(pattern).$(ext))))))

--- a/template/Makefile
+++ b/template/Makefile
@@ -1,8 +1,14 @@
 LIBDIR := lib
 include $(LIBDIR)/main.mk
 
+ifneq (,$(wildcard .gitmodules))
+ifneq (,$(shell grep "path = $(LIBDIR)" .gitmodules))
+SUBMODULE = true
+endif
+endif
+
 $(LIBDIR)/main.mk:
-ifneq (,$(shell git submodule status $(LIBDIR) 2>/dev/null))
+ifeq (true,$(SUBMODULE))
 	git submodule sync
 	git submodule update $(CLONE_ARGS) --init
 else


### PR DESCRIPTION
Doing a little exploration of what the remaining sources of slowness are in the template, it appears that each git submodule call is fairly slow (0.5-3 seconds), and there are two of them.  Replacing that with a check that .gitmodules exists && contains "path = $(LIBDIR)" appears to be a fair bit faster and is still accurate based on a quick test of a submodule repo.

The gains aren't dramatic, but the functionality appears to be equivalent.