### PR TITLE
make tags: create tags file to facilitate navigation

### DIFF
--- a/gen-tags.pl
+++ b/gen-tags.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+#
+# Generate tags file for explicit and implicit anchors in the Markdown drafts.
+# This facilitates jumping to the marked place from the reference.
+#
+# Usage: ./gen-tags.pl *.md > tags
+#
+# (In vim, add the dash to the keyword definition via :set iskeyword+=-
+# to be able to jump to anchors with dashes in them.)
+
+sub to_re {
+    my $search_str = quotemeta shift;
+    $search_str =~ s/\\\{/{/g;  # Revert left curly brace escape just
+                                # performed by quotemeta().
+    return $search_str;
+}
+
+while (<>) {
+    if (/^(#+\s+(.+?))\s*(?:$|\{)/) {   # Implicit anchor for header
+        $re = to_re $1;
+        $link = $2;
+        $link =~ y/A-Z/a-z/;
+        $link =~ s/[^A-Za-z0-9]/-/g;
+        push @tags, "$link\t$ARGV\t/^$re/\n";
+    }
+    if (/(\{#\s*(.+?)\s*})/) {          # Explicit anchor
+        $re = to_re $1;
+        $link = $2;
+        push @tags, "$2\t$ARGV\t/$re/\n";
+    }
+    if (/(\{:\s*#\s*(\S+))/) {          # Explicit anchor (for figure)
+        $re = to_re $1;
+        $link = $2;
+        push @tags, "$2\t$ARGV\t/$re/\n";
+    }
+}
+
+print sort @tags;

--- a/main.mk
+++ b/main.mk
@@ -176,11 +176,14 @@ fix-lint::
 	done
 	sed -i~ -e 's/ *$$//' $(join $(drafts),$(draft_types))
 
+tags:: $(addsuffix .md,$(drafts)) $(LIBDIR)/gen-tags.pl
+	perl $(LIBDIR)/gen-tags.pl $(addsuffix .md,$(drafts)) > tags
+
 ## Cleanup
 COMMA := ,
 .PHONY: clean
 clean::
-	-rm -f .tags $(targets_file) issues.json \
+	-rm -f tags .tags $(targets_file) issues.json \
 	    $(addsuffix .{txt$(COMMA)html$(COMMA)pdf},$(drafts)) index.html \
 	    $(addsuffix -[0-9][0-9].{xml$(COMMA)md$(COMMA)org$(COMMA)txt$(COMMA)html$(COMMA)pdf},$(drafts)) \
 	    $(filter-out $(join $(drafts),$(draft_types)),$(addsuffix .xml,$(drafts))) \


### PR DESCRIPTION
New utility gen-tags.pl creates file "tags" which can be used by vim
(and, presumably, emacs) users to jump to anchor definitions.  A tag
entry is also generated for each Markdown header.