### PR TITLE
<span class="tt"> should be monospace

### DIFF
--- a/style.css
+++ b/style.css
@@ -72,7 +72,7 @@ table.header td, table#rfc\.headerblock td {
   line-height: 28px;
 }
 
-samp, tt, code, pre {
+samp, tt, code, pre, span.tt {
   font: 13.5px Consolas, monospace;
   font-size-adjust: none;
 }


### PR DESCRIPTION
rfc2629.xslt generates `<span class="tt">` for `<spanx style='verb'>` input.

https://github.com/reschke/xml2rfc/blob/b56ed44209a5ecfc07285484609dd97e899384e4/rfc2629.xslt#L4296 generates the `<span>`, and https://github.com/reschke/xml2rfc/blob/b56ed44209a5ecfc07285484609dd97e899384e4/rfc2629.xslt#L6519 styles it.