### PR TITLE
Clean GHPAGES_EXTRA from the target dir.

### DIFF
--- a/ghpages.mk
+++ b/ghpages.mk
@@ -90,8 +90,8 @@ cleanup-ghpages: $(GHPAGES_ROOT)
 
 # Clean up contents of target directory
 	@if [ -d $(GHPAGES_TARGET) ]; then \
-	  echo git -C $(GHPAGES_ROOT) rm -fq --ignore-unmatch -- $(GHPAGES_TARGET)/draft-*.html $(GHPAGES_TARGET)/draft-*.txt; \
-	  git -C $(GHPAGES_ROOT) rm -fq --ignore-unmatch -- $(GHPAGES_TARGET)/draft-*.html $(GHPAGES_TARGET)/draft-*.txt; \
+	  echo git -C $(GHPAGES_ROOT) rm -fq --ignore-unmatch -- $(GHPAGES_TARGET)/draft-*.html $(GHPAGES_TARGET)/draft-*.txt $(addprefix $(GHPAGES_TARGET)/,$(GHPAGES_EXTRA)); \
+	  git -C $(GHPAGES_ROOT) rm -fq --ignore-unmatch -- $(GHPAGES_TARGET)/draft-*.html $(GHPAGES_TARGET)/draft-*.txt $(addprefix $(GHPAGES_TARGET)/,$(GHPAGES_EXTRA)); \
 	fi
 
 


### PR DESCRIPTION
https://wicg.github.io/webpackage/loading.html hasn't updated since August, and
https://travis-ci.org/WICG/webpackage/builds/470676744#L1095 seems to indicate it's because `git clone` ran after `loading.html` was built, which led to `/tmp/ghpages5583/loading.html` being newer than its source file, even though it ought to be older.

I don't know what changed in August to make this happen, it only sometimes reproduces locally, and I haven't tested the change on TravisCI, but it seems in line with the intent of the rest of the changed line.