### PR TITLE
Style: `samp`, `tt`, and `code` in abstracts.

### DIFF
--- a/style.css
+++ b/style.css
@@ -67,13 +67,14 @@ table.header td, table#rfc\.headerblock td {
   line-height: 100%;
   margin: 10px 0 32px;
 }
-#rfc\.abstract+p, #rfc\.abstract p {
+#rfc\.abstract+p, #rfc\.abstract+p code, #rfc\.abstract+p samp, #rfc\.abstract+p tt {
   font-size: 20px;
   line-height: 28px;
 }
 
 samp, tt, code, pre, span.tt {
-  font: 13.5px Consolas, monospace;
+  font-size: 13.5px;
+  font-family: Consolas, monospace;
   font-size-adjust: none;
 }
 pre {


### PR DESCRIPTION
The `samp, tt, code, pre, span.tt` rule overrides the font size specified in the`#rfc\.abstract+p` rule, which looks odd indeed when one of those elements is included in a document's abstract. This patch increases the specificity of the abstract rule to ensure that such elements render correctly.