### PR TITLE
Pull only changes to issues/PR list

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Martin Thomson <martin.thomson@gmail.com>"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates coreutils curl git make ssh libxml2-utils xsltproc \
     python3-minimal python3-lxml python3-pip python3-setuptools python3-wheel \
-    mmark ruby \
+    mmark ruby jq \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get autoremove -y && apt-get clean -y
 

--- a/issues.mk
+++ b/issues.mk
@@ -28,7 +28,8 @@ issues.json: $(drafts_source)
 	fi; \
 	tmp_headers=$$(mktemp /tmp/$(basename $(notdir $@))-headers.XXXXXX);  \
 	tmp_old=$$(mktemp /tmp/$(basename $(notdir $@))-old.XXXXXX); \
-	merge=false; \
+	tmp_new=$$(mktemp /tmp/$(basename $(notdir $@))-new.XXXXXX); \
+	trap 'rm -f $$tmp_headers $$tmp_new $$tmp_old' EXIT; \
 	if git show $(GH_ISSUES):$@ > $$tmp_old && [ ! -s "$$tmp_old" ]; then \
 		url="https://api.github.com/repos/$(GITHUB_REPO_FULL)$(basename $(notdir $@))?state=all&since=$$(git log -n 1 --pretty=format:%cI $(GH_ISSUES) -- $@)"; \
 	    merge=true; \
@@ -36,8 +37,6 @@ issues.json: $(drafts_source)
 		url="https://api.github.com/repos/$(GITHUB_REPO_FULL)$(basename $(notdir $@))?state=all"; \
 		merge=false; \
 	fi; \
-	tmp_new=$$(mktemp /tmp/$(basename $(notdir $@))-new.XXXXXX); \
-	trap 'rm -f $$tmp_headers $$tmp_new $$tmp_old' EXIT; \
 	echo '[' > $$tmp_new; \
 	while [ -n "$$url" ]; do \
 	  echo "Fetching $(basename $(notdir $@)) from $$url"; \

--- a/issues.mk
+++ b/issues.mk
@@ -65,7 +65,7 @@ pulls.json: issues.json
 	     $$(($$(date '+%s')-28800)) -lt "$$(git log -n 1 --pretty=format:%ct $(GH_ISSUES) -- $@)" ] 2>/dev/null; then \
 	    skip=true; echo 'Skipping update of $@ (most recent update was in the last 8 hours)'; \
 	fi; \
-	if [ "$$skip" = true ]; then \
+	if [ "$$skip" = true ] || [! -s "$<"]; then \
 	    git show $(GH_ISSUES):$@ > $@; exit; \
 	fi; \
 	jq --slurpfile issues $< -n '[ $issues | .[] | map(select( .pull_request)) | sort_by(.number)]' > $@;

--- a/tests/git.feature
+++ b/tests/git.feature
@@ -2,14 +2,14 @@ Feature: git integration
 
   Scenario:  make ghpages
     Given a configured git repo with a Kramdown draft
-     when make "ghpages" is run with "PUSH_GHPAGES=false"
+     when make "ghpages" is run
      then it succeeds
      and a branch is created called "gh-pages" containing "index.html"
      and documents are added to gh-pages
 
   Scenario:  make ghissues
     Given a configured git repo with a Kramdown draft
-     when make "ghissues" is run with "DISABLE_ISSUE_FETCH=true"
+     when make "ghissues" is run
      then it succeeds
      and a branch is created called "gh-pages" containing "issues.json"
 

--- a/tests/steps/build_commands.py
+++ b/tests/steps/build_commands.py
@@ -10,6 +10,7 @@ import fileinput
 
 git_commit = ["git", "-c", "user.name=Behave Tests", "-c",
               "user.email=behave@example.com", "commit"]
+offline_make_options = ["PUSH_GHPAGES=false", "FETCH_ISSUES=false"]
 
 
 @contextmanager
@@ -48,17 +49,17 @@ def step_impl(context, option):
 
 @when(u'make is run')
 def step_impl(context):
-    run_with_capture(context, ["make"])
+    run_with_capture(context, ["make"] + offline_make_options)
 
 
 @when(u'make "{target}" is run')
 def step_impl(context, target):
-    run_with_capture(context, ["make", target])
+    run_with_capture(context, ["make", target] + offline_make_options)
 
 
 @when(u'make "{target}" is run with "{option}"')
 def step_impl(context, target, option):
-    run_with_capture(context, ["make", target, option])
+    run_with_capture(context, ["make", target, option] + offline_make_options)
 
 
 @when(u'the draft is broken')


### PR DESCRIPTION
Primary change:  Get the time of the last issues pull, ask the GitHub API for any issues that have changed since that time, and merge the JSON, discarding old instances of modified issues.

Follow-on changes:
- Pulls are a subset of issues in the GitHub API and the /pulls endpoint doesn't support the "since" parameter, so pulls.json is now extracted from issues.json with a filter.
- Forces PUSH_GHPAGES=false and DISABLE_ISSUE_FETCH=true in tests, because Circle keeps trying to push to gh-pages from the test repos in some cases.  This just makes them run offline always.

In particular, we should check that this is still capturing any properties of the pull requests that we care about.  Having compared them, we are losing some properties, but I think that to be capturing a meaningful record of all discussion in the event the repo went away, we'd need to be doing a lot more crawling (e.g. to download all comments from the API, since they're not included in the parent object).