### PR TITLE
Also build with `--raw`

### DIFF
--- a/id.mk
+++ b/id.mk
@@ -23,6 +23,7 @@ drafts_prev := $(foreach draft,$(drafts),$(draft)-$(f_prev_tag))
 drafts_with_prev := $(foreach draft,$(drafts),$(if $(f_prev_tag),$(draft)))
 
 drafts_txt := $(addsuffix .txt,$(drafts))
+drafts_raw := $(addsuffix .raw.txt,$(drafts))
 drafts_html := $(addsuffix .html,$(drafts))
 drafts_xml := $(addsuffix .xml,$(drafts))
 drafts_next_txt := $(addsuffix .txt,$(drafts_next))

--- a/main.mk
+++ b/main.mk
@@ -1,5 +1,5 @@
 .PHONY: latest
-latest:: txt raw html
+latest:: txt html
 
 .DELETE_ON_ERROR:
 

--- a/main.mk
+++ b/main.mk
@@ -1,5 +1,5 @@
 .PHONY: latest
-latest:: txt html
+latest:: txt raw html
 
 .DELETE_ON_ERROR:
 
@@ -12,8 +12,9 @@ include $(LIBDIR)/upload.mk
 include $(LIBDIR)/update.mk
 
 ## Basic Targets
-.PHONY: txt html pdf
+.PHONY: txt raw html pdf
 txt:: $(drafts_txt)
+raw:: $(drafts_raw)
 html:: $(drafts_html)
 pdf:: $(addsuffix .pdf,$(drafts))
 
@@ -75,12 +76,18 @@ $(XSLTDIR):
 
 %.txt: %.cleanxml
 	$(xml2rfc) $< -o $@ --text
+
+%.raw.txt: %.cleanxml
+	$(xml2rfc) $< -o $@ --raw
 else
 %.htmltmp: %.xml
 	$(xml2rfc) $< -o $@ --html
 
 %.txt: %.xml
 	$(xml2rfc) $< -o $@ --text
+
+%.raw.txt: %.xml
+	$(xml2rfc) $< -o $@ --raw
 endif
 
 %.html: %.htmltmp $(LIBDIR)/addstyle.sed $(LIBDIR)/style.css
@@ -182,7 +189,7 @@ COMMA := ,
 .PHONY: clean
 clean::
 	-rm -f .tags $(targets_file) issues.json \
-	    $(addsuffix .{txt$(COMMA)html$(COMMA)pdf},$(drafts)) index.html \
-	    $(addsuffix -[0-9][0-9].{xml$(COMMA)md$(COMMA)org$(COMMA)txt$(COMMA)html$(COMMA)pdf},$(drafts)) \
+	    $(addsuffix .{txt$(COMMA)raw.txt$(COMMA)html$(COMMA)pdf},$(drafts)) index.html \
+	    $(addsuffix -[0-9][0-9].{xml$(COMMA)md$(COMMA)org$(COMMA)txt$(COMMA)raw.txt$(COMMA)html$(COMMA)pdf},$(drafts)) \
 	    $(filter-out $(join $(drafts),$(draft_types)),$(addsuffix .xml,$(drafts))) \
 	    $(uploads) $(draft_diffs)


### PR DESCRIPTION
The `--raw` output from `xml2rfc` is sometimes more useful than the regular `--txt` build (when diffing, for example). This very simple PR adds it to the versions that are built by default. Tested with `make`, `make draft-foo.raw.txt`, and `make clean`.

I've found this personally useful. If you feel that this is not a valuable contribution, feel free to close. My feelings will not be hurt. :)