### PR TITLE
Trim history of gh-pages

### DIFF
--- a/ghpages.mk
+++ b/ghpages.mk
@@ -78,11 +78,10 @@ cleanup-ghpages: $(GHPAGES_ROOT)
 	done;
 
 # Drop old gh-pages commits (keep 30-60 days of history)
-	@CUTOFF_30=$$(($$(date '+%s')-2592000)); \
-	CUTOFF_60=$$(($$(date '+%s')-5184000)); \
-	ROOT=$$(git -C $(GHPAGES_TARGET) rev-list --max-parents=0 gh-pages); \
-	if [ `git -C $(GHPAGES_ROOT) show -s --format=%ct $$ROOT` -lt $$CUTOFF_60 ]; then \
-	  git -C $(GHPAGES_ROOT) replace --graft `git rev-list --min-age=$$CUTOFF_30 --max-count=1 gh-pages`; \
+	@KEEP=$$((`date '+%s'`-2592000)); CUTOFF=$$((`date '+%s'`-5184000)); \
+	ROOT=`git -C $(GHPAGES_TARGET) rev-list --max-parents=0 gh-pages`; \
+	if [ `git -C $(GHPAGES_ROOT) show -s --format=%ct $$ROOT` -lt $$CUTOFF ]; then \
+	  git -C $(GHPAGES_ROOT) replace --graft `git rev-list --min-age=$$KEEP --max-count=1 gh-pages` && \
 	  git -C $(GHPAGES_ROOT) filter-branch gh-pages; \
 	fi
 
@@ -111,13 +110,13 @@ ghpages: cleanup-ghpages $(GHPAGES_ALL)
 	  git -C $(GHPAGES_ROOT) $(CI_AUTHOR) commit -m "Script updating gh-pages from $(shell git rev-parse --short HEAD). [ci skip]"; fi
 ifeq (true,$(PUSH_GHPAGES))
 ifneq (,$(if $(CI_HAS_WRITE_KEY),1,$(if $(GH_TOKEN),,1)))
-	git -C $(GHPAGES_ROOT) push https://github.com/$(GITHUB_REPO_FULL) gh-pages --force
+	git -C $(GHPAGES_ROOT) push -f https://github.com/$(GITHUB_REPO_FULL) gh-pages
 else
-	@echo git -C $(GHPAGES_ROOT) push -q https://github.com/$(GITHUB_REPO_FULL) gh-pages --force
-	@git -C $(GHPAGES_ROOT) push -q https://$(GH_TOKEN)@github.com/$(GITHUB_REPO_FULL) gh-pages --force >/dev/null 2>&1
+	@echo git -C $(GHPAGES_ROOT) push -qf https://github.com/$(GITHUB_REPO_FULL) gh-pages
+	@git -C $(GHPAGES_ROOT) push -qf https://$(GH_TOKEN)@github.com/$(GITHUB_REPO_FULL) gh-pages >/dev/null 2>&1
 endif
 else
-	git -C $(GHPAGES_ROOT) push origin gh-pages --force
+	git -C $(GHPAGES_ROOT) push -f origin gh-pages
 endif # PUSH_GHPAGES
 	-rm -rf $(GHPAGES_ROOT)
 

--- a/ghpages.mk
+++ b/ghpages.mk
@@ -77,6 +77,15 @@ cleanup-ghpages: $(GHPAGES_ROOT)
 	  git remote prune $$remote; \
 	done;
 
+# Drop old gh-pages commits (keep 30-60 days of history)
+	@CUTOFF_30=$$(($$(date '+%s')-2592000)); \
+	CUTOFF_60=$$(($$(date '+%s')-5184000)); \
+	ROOT=$$(git -C $(GHPAGES_TARGET) rev-list --max-parents=0 gh-pages); \
+	if [ `git -C $(GHPAGES_ROOT) show -s --format=%ct $$ROOT` -lt $$CUTOFF_60 ]; then \
+	  git -C $(GHPAGES_ROOT) replace --graft `git rev-list --min-age=$$CUTOFF_30 --max-count=1 gh-pages`; \
+	  git -C $(GHPAGES_ROOT) filter-branch gh-pages; \
+	fi
+
 # Clean up obsolete directories (2592000 = 30 days)
 	@CUTOFF=$$(($$(date '+%s')-2592000)); \
 	MAYBE_OBSOLETE=`comm -13 <(git branch -a | sed -e 's,.*[ /],,' | sort | uniq) <(ls $(GHPAGES_ROOT) | sed -e 's,.*/,,')`; \
@@ -94,7 +103,6 @@ cleanup-ghpages: $(GHPAGES_ROOT)
 	  git -C $(GHPAGES_ROOT) rm -fq --ignore-unmatch -- $(GHPAGES_TARGET)/draft-*.html $(GHPAGES_TARGET)/draft-*.txt $(addprefix $(GHPAGES_TARGET)/,$(GHPAGES_EXTRA)); \
 	fi
 
-
 .PHONY: ghpages gh-pages
 gh-pages: ghpages
 ghpages: cleanup-ghpages $(GHPAGES_ALL)
@@ -103,13 +111,13 @@ ghpages: cleanup-ghpages $(GHPAGES_ALL)
 	  git -C $(GHPAGES_ROOT) $(CI_AUTHOR) commit -m "Script updating gh-pages from $(shell git rev-parse --short HEAD). [ci skip]"; fi
 ifeq (true,$(PUSH_GHPAGES))
 ifneq (,$(if $(CI_HAS_WRITE_KEY),1,$(if $(GH_TOKEN),,1)))
-	git -C $(GHPAGES_ROOT) push https://github.com/$(GITHUB_REPO_FULL) gh-pages
+	git -C $(GHPAGES_ROOT) push https://github.com/$(GITHUB_REPO_FULL) gh-pages --force
 else
-	@echo git -C $(GHPAGES_ROOT) push -q https://github.com/$(GITHUB_REPO_FULL) gh-pages
-	@git -C $(GHPAGES_ROOT) push -q https://$(GH_TOKEN)@github.com/$(GITHUB_REPO_FULL) gh-pages >/dev/null 2>&1
+	@echo git -C $(GHPAGES_ROOT) push -q https://github.com/$(GITHUB_REPO_FULL) gh-pages --force
+	@git -C $(GHPAGES_ROOT) push -q https://$(GH_TOKEN)@github.com/$(GITHUB_REPO_FULL) gh-pages --force >/dev/null 2>&1
 endif
 else
-	git -C $(GHPAGES_ROOT) push origin gh-pages
+	git -C $(GHPAGES_ROOT) push origin gh-pages --force
 endif # PUSH_GHPAGES
 	-rm -rf $(GHPAGES_ROOT)
 

--- a/template/.circleci/config.yml
+++ b/template/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
 
       - run:
           name: "Prepare for Caching"
-          command: "git gc --auto"
+          command: "git gc --auto --prune=now"
 
       - save_cache:
           name: "Saving Cache - Git"


### PR DESCRIPTION
If the oldest commit on gh-pages is more than 60 days old, drop all commits from gh-pages which are more than 30 days old.  Note that this involves a force-push of gh-pages back to origin, but that should generally be okay; no one is likely to be basing their own commits off of gh-pages.

Hopefully this should permit GitHub to garbage collect a ton of old and very large state, reducing the size of the QUIC repo in the near future.  (And, of course, the document versions being dropped can be rebuilt from the git history of the main branch.)

_(Note: the Behave tests failed on this commit, but the failing test is for `make ghissues` and shouldn't be impacted by this change.  Also, the test succeeds on my local branch.  I'm not quite sure what to make of the failure.)_