### PR TITLE
Don't push tests

### DIFF
--- a/tests/git.feature
+++ b/tests/git.feature
@@ -9,7 +9,7 @@ Feature: git integration
 
   Scenario:  make ghissues
     Given a configured git repo with a Kramdown draft
-     when make "ghissues" is run with "DISABLE_ISSUE_FETCH=true"
+     when make "ghissues" is run with "PUSH_GHPAGES=false"
      then it succeeds
      and a branch is created called "gh-pages" containing "issues.json"
 


### PR DESCRIPTION
I think this was causing my test failure on #207; you explicitly pass in `DISABLE_ISSUE_FETCH = true`, but it still decided to push because it was running in CI and saw something it liked. `PUSH_GHPAGES=false` implies the other, but explicitly forces it not to attempt a push.