### PR TITLE
Expire and GC before caching

### DIFF
--- a/template/.circleci/config.yml
+++ b/template/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
 
       - run:
           name: "Prepare for Caching"
-          command: "git gc --auto --prune=now"
+          command: "git reflog expire --expire=now --all && git gc --prune=now"
 
       - save_cache:
           name: "Saving Cache - Git"


### PR DESCRIPTION
This should clean up the cached object sizes.  It'll run long when gh-pages gets re-written, but that's only once a month.  I already tested it on quicwg/base-drafts; the cached archive is now 30MB instead of 881MB.