### PR TITLE
Variable names need to match to work

### DIFF
--- a/archive_repo.py
+++ b/archive_repo.py
@@ -571,7 +571,7 @@ if args.refFile:
 ## Download from GitHub the full issues list (if no reference) or the updated issues list (if reference)
 issue_cursor = None
 get_more_issues = True
-just_copy_old_file = True if args.refFile else False
+just_copy_old_file = True if issue_ref and (pr_ref or args.issuesOnly) else False
 (owner, repo) = args.repo.split("/", 1)
 
 while get_more_issues:
@@ -617,7 +617,7 @@ while get_more_issues:
         if number in issue_ref.keys():
             del issue_ref[number]
         issue_ref[number] = issue
-        just_copy_old_issues = False
+        just_copy_old_file = False
 
     get_more_issues = issues["pageInfo"]["hasNextPage"]
     issue_cursor = issues["pageInfo"]["endCursor"]


### PR DESCRIPTION
Found the zero-length bug, which was actually a pair -- `just_copy_old_file` was getting set if a file was provided, not if it was useful, and it was getting unset by the wrong name in the issues download.  If there were only new issues, not new PRs, the tool would reuse the old file, which was empty in the initial case.