### PR TITLE
Integrate with Circle's test UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+      - store_test_results:
+          path: /tmp/artifacts
+
 
 workflows:
   version: 2


### PR DESCRIPTION
In Circle's new UI, they can display metadata about test outcomes; since we're already generating the files, it's trivial to also provide them as test results.