### PR TITLE
add CDDL validation and CBOR diagnostic tools

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && \
  && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log \
  && apt-get autoremove -y && apt-get clean -y
 
+RUN gem install cddl cbor-diag
+
 ENV USER idci
 ENV LOGNAME $USER
 ENV HOSTNAME $USER


### PR DESCRIPTION
This adds `cddl(1)` and `cbor-diag(1)` to the CI docker image toolchain.

It allows validating inlined CDDL and checking CBOR examples against CDDL.

An example usage is the RATS EAT spec:

* https://github.com/ietf-rats-wg/eat/tree/master/cddl
* https://github.com/ietf-rats-wg/eat/tree/master/Makefile

It looks to me like it could be generally useful?

cheers!