### PR TITLE
Make setup-note.sh work on macOS

### DIFF
--- a/setup-note.sh
+++ b/setup-note.sh
@@ -28,9 +28,11 @@ ml() {
     echo "https://mailarchive.ietf.org/arch/browse/$1/"
 }
 
+wgu="$(echo "${wg}" | tr '[a-z]' '[A-Z]')"
+
 echo '<note title="Discussion Venues" removeInRFC="true">'
 echo "<t>Discussion of this document takes place on the
-  ${wg^^} Working Group mailing list (${ML:-${wg}@ietf.org}),
+  ${wgu} Working Group mailing list (${ML:-${wg}@ietf.org}),
   which is archived at <eref target=\"$(ml "${wg}")\"/>.</t>"
 echo "<t>Source for this draft and an issue tracker can be found at
   <eref target=\"https://github.com/${user}/${repo}\"/>.</t>"


### PR DESCRIPTION
Bash case operators were added in Bash 4, and macOS runs a
version of Bash from the Paleolithic. This uses tr instead to
support older versions of Bash.