### PR TITLE
Run tools inside the i-d-toolchain Docker image

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -2,11 +2,23 @@
 # All are assumed to be on the path, but you can override these
 # in the environment, or command line.
 
+ifneq (,$(USE_DOCKER))
+XML2RFC_REFCACHEDIR := /id/.cache/xml2rfc
+KRAMDOWN_REFCACHEDIR := $(XML2RFC_REFCACHEDIR)
+IMAGE := ghcr.io/larseggert/i-d-toolchain:latest
+DOCKER := docker run \
+		--env XML2RFC_REFCACHEDIR=${XML2RFC_REFCACHEDIR} \
+		--env KRAMDOWN_REFCACHEDIR=${KRAMDOWN_REFCACHEDIR} \
+		--volume ${CURDIR}:/id:delegated \
+		--interactive \
+		--cap-add=SYS_ADMIN ${IMAGE}
+endif
+
 # Mandatory:
 #   https://pypi.python.org/pypi/xml2rfc
 XML2RFC_RFC_BASE_URL := https://datatracker.ietf.org/doc/html/
 XML2RFC_ID_BASE_URL := https://datatracker.ietf.org/doc/html/
-xml2rfc ?= xml2rfc -q -s 'Setting consensus="true" for IETF STD document' --rfc-base-url $(XML2RFC_RFC_BASE_URL) --id-base-url $(XML2RFC_ID_BASE_URL)
+xml2rfc ?= ${DOCKER} xml2rfc -q -s 'Setting consensus="true" for IETF STD document' --rfc-base-url $(XML2RFC_RFC_BASE_URL) --id-base-url $(XML2RFC_ID_BASE_URL)
 # Tell kramdown not to generate targets on references so the above takes effect.
 KRAMDOWN_NO_TARGETS := true
 export KRAMDOWN_NO_TARGETS
@@ -15,10 +27,10 @@ export KRAMDOWN_PERSISTENT
 
 # If you are using markdown files use either kramdown-rfc2629 or mmark
 #   https://github.com/cabo/kramdown-rfc2629
-kramdown-rfc2629 ?= kramdown-rfc2629
+kramdown-rfc2629 ?= ${DOCKER} kramdown-rfc2629
 
 #  mmark (https://github.com/miekg/mmark)
-mmark ?= mmark
+mmark ?= ${DOCKER} mmark
 
 # If you are using outline files:
 #   https://github.com/Juniper/libslax/tree/master/doc/oxtradoc
@@ -26,32 +38,32 @@ oxtradoc ?= oxtradoc.in
 
 # When using rfc2629.xslt extensions:
 #   https://greenbytes.de/tech/webdav/rfc2629xslt.html
-xsltproc ?= xsltproc
+xsltproc ?= ${DOCKER} xsltproc
 
 # For sanity checkout your draft:
 #   https://tools.ietf.org/tools/idnits/
-idnits ?= idnits
+idnits ?= ${DOCKER} idnits
 
 # For diff:
 #   https://tools.ietf.org/tools/rfcdiff/
-rfcdiff ?= rfcdiff
+rfcdiff ?= ${DOCKER} rfcdiff
 
 # For generating PDF:
 #   https://www.gnu.org/software/enscript/
-enscript ?= enscript
+enscript ?= ${DOCKER} enscript
 #   http://www.ghostscript.com/
-ps2pdf ?= ps2pdf
+ps2pdf ?= ${DOCKER} ps2pdf
 
 # Where to get references
 XML_RESOURCE_ORG_PREFIX ?= https://xml2rfc.tools.ietf.org/public/rfc
 
 # This is for people running macs
-SHELL := bash
+SHELL := ${DOCKER} bash
 
-python ?= /usr/bin/env python3
+python ?= ${DOCKER} /usr/bin/env python3
 
 # For uploading draft "releases" to the datatracker.
-curl ?= curl -sS
+curl ?= ${DOCKER} curl -sS
 DATATRACKER_UPLOAD_URL ?= https://datatracker.ietf.org/api/submit
 
 # The type of index that is created for gh-pages.
@@ -59,7 +71,7 @@ DATATRACKER_UPLOAD_URL ?= https://datatracker.ietf.org/api/submit
 INDEX_FORMAT ?= html
 
 # For spellchecking: pip install --user codespell
-codespell ?= codespell
+codespell ?= ${DOCKER} codespell
 
 # Setup a shared cache for xml2rfc and kramdown-rfc2629
 ifeq (,$(KRAMDOWN_REFCACHEDIR))

--- a/config.mk
+++ b/config.mk
@@ -2,23 +2,23 @@
 # All are assumed to be on the path, but you can override these
 # in the environment, or command line.
 
+DOCKER_IMAGE := ghcr.io/larseggert/i-d-toolchain:latest
 ifneq (,$(USE_DOCKER))
 XML2RFC_REFCACHEDIR := /id/.cache/xml2rfc
 KRAMDOWN_REFCACHEDIR := $(XML2RFC_REFCACHEDIR)
-IMAGE := ghcr.io/larseggert/i-d-toolchain:latest
-DOCKER := docker run \
+DOCKER_CMD := docker run \
 		--env XML2RFC_REFCACHEDIR=${XML2RFC_REFCACHEDIR} \
 		--env KRAMDOWN_REFCACHEDIR=${KRAMDOWN_REFCACHEDIR} \
 		--volume ${CURDIR}:/id:delegated \
 		--interactive \
-		--cap-add=SYS_ADMIN ${IMAGE}
+		--cap-add=SYS_ADMIN ${DOCKER_IMAGE}
 endif
 
 # Mandatory:
 #   https://pypi.python.org/pypi/xml2rfc
 XML2RFC_RFC_BASE_URL := https://datatracker.ietf.org/doc/html/
 XML2RFC_ID_BASE_URL := https://datatracker.ietf.org/doc/html/
-xml2rfc ?= ${DOCKER} xml2rfc -q -s 'Setting consensus="true" for IETF STD document' --rfc-base-url $(XML2RFC_RFC_BASE_URL) --id-base-url $(XML2RFC_ID_BASE_URL)
+xml2rfc ?= ${DOCKER_CMD} xml2rfc -q -s 'Setting consensus="true" for IETF STD document' --rfc-base-url $(XML2RFC_RFC_BASE_URL) --id-base-url $(XML2RFC_ID_BASE_URL)
 # Tell kramdown not to generate targets on references so the above takes effect.
 KRAMDOWN_NO_TARGETS := true
 export KRAMDOWN_NO_TARGETS
@@ -27,10 +27,10 @@ export KRAMDOWN_PERSISTENT
 
 # If you are using markdown files use either kramdown-rfc2629 or mmark
 #   https://github.com/cabo/kramdown-rfc2629
-kramdown-rfc2629 ?= ${DOCKER} kramdown-rfc2629
+kramdown-rfc2629 ?= ${DOCKER_CMD} kramdown-rfc2629
 
 #  mmark (https://github.com/miekg/mmark)
-mmark ?= ${DOCKER} mmark
+mmark ?= ${DOCKER_CMD} mmark
 
 # If you are using outline files:
 #   https://github.com/Juniper/libslax/tree/master/doc/oxtradoc
@@ -38,32 +38,32 @@ oxtradoc ?= oxtradoc.in
 
 # When using rfc2629.xslt extensions:
 #   https://greenbytes.de/tech/webdav/rfc2629xslt.html
-xsltproc ?= ${DOCKER} xsltproc
+xsltproc ?= ${DOCKER_CMD} xsltproc
 
 # For sanity checkout your draft:
 #   https://tools.ietf.org/tools/idnits/
-idnits ?= ${DOCKER} idnits
+idnits ?= ${DOCKER_CMD} idnits
 
 # For diff:
 #   https://tools.ietf.org/tools/rfcdiff/
-rfcdiff ?= ${DOCKER} rfcdiff
+rfcdiff ?= ${DOCKER_CMD} rfcdiff
 
 # For generating PDF:
 #   https://www.gnu.org/software/enscript/
-enscript ?= ${DOCKER} enscript
+enscript ?= ${DOCKER_CMD} enscript
 #   http://www.ghostscript.com/
-ps2pdf ?= ${DOCKER} ps2pdf
+ps2pdf ?= ${DOCKER_CMD} ps2pdf
 
 # Where to get references
 XML_RESOURCE_ORG_PREFIX ?= https://xml2rfc.tools.ietf.org/public/rfc
 
 # This is for people running macs
-SHELL := ${DOCKER} bash
+SHELL := ${DOCKER_CMD} bash
 
-python ?= ${DOCKER} /usr/bin/env python3
+python ?= ${DOCKER_CMD} /usr/bin/env python3
 
 # For uploading draft "releases" to the datatracker.
-curl ?= ${DOCKER} curl -sS
+curl ?= ${DOCKER_CMD} curl -sS
 DATATRACKER_UPLOAD_URL ?= https://datatracker.ietf.org/api/submit
 
 # The type of index that is created for gh-pages.
@@ -71,7 +71,7 @@ DATATRACKER_UPLOAD_URL ?= https://datatracker.ietf.org/api/submit
 INDEX_FORMAT ?= html
 
 # For spellchecking: pip install --user codespell
-codespell ?= ${DOCKER} codespell
+codespell ?= ${DOCKER_CMD} codespell
 
 # Setup a shared cache for xml2rfc and kramdown-rfc2629
 ifeq (,$(KRAMDOWN_REFCACHEDIR))

--- a/main.mk
+++ b/main.mk
@@ -57,7 +57,7 @@ NOT_CURRENT = $(filter-out $(basename $<),$(drafts))
 MD_PRE += | sed -e '$(join $(addprefix s/,$(addsuffix -latest/,$(NOT_CURRENT))), \
 		$(addsuffix /g;,$(NOT_CURRENT)))'
 endif
-MD_POST := | $(LIBDIR)/add-note.py
+MD_POST := | ${python} $(LIBDIR)/add-note.py
 ifneq (true,$(USE_XSLT))
 MD_POST += | $(xml2rfc) --v2v3 /dev/stdin -o /dev/stdout
 endif
@@ -231,6 +231,10 @@ fix-lint-default-branch:
 	if ! git rev-parse --abbrev-ref refs/remotes/$(GIT_REMOTE)/HEAD >/dev/null 2>&1; then \
 	  echo "ref: refs/remotes/$(GIT_REMOTE)/$$(git rev-parse --abbrev-ref HEAD)" > $$(git rev-parse --git-dir)/refs/remotes/$(GIT_REMOTE)/HEAD; \
 	fi
+
+.PHONY: update-docker
+update-docker:
+	docker image pull ghcr.io/larseggert/i-d-toolchain:latest
 
 ## Cleanup
 COMMA := ,

--- a/main.mk
+++ b/main.mk
@@ -234,7 +234,7 @@ fix-lint-default-branch:
 
 .PHONY: update-docker
 update-docker:
-	docker image pull ghcr.io/larseggert/i-d-toolchain:latest
+	docker image pull ${DOCKER_IMAGE}
 
 ## Cleanup
 COMMA := ,


### PR DESCRIPTION
If USE_DOCKER is defined, this PR will have the Makefile run all commands inside an [i-d-toolchain](https://github.com/larseggert/i-d-toolchain) Docker container.

The image for this container can be updated via the "update-docker" `make` target.

This means that the only thing that needs to be installed locally is `make`.