### PR TITLE
Use the ietf.org rfcdiff

### DIFF
--- a/build-index.sh
+++ b/build-index.sh
@@ -19,7 +19,7 @@ all_drafts=("$@")
 gh="https://github.com/${user}/${repo}"
 
 function rfcdiff() {
-    echo "https://tools.ietf.org/rfcdiff?url1=${1}&amp;url2=${2}"
+    echo "https://www.ietf.org/rfcdiff?url1=${1}&amp;url2=${2}"
 }
 
 function reldot() {


### PR DESCRIPTION
Note that the first URL fed to rfcdiff still leads to tools.ietf.org, because datatracker and www don't have a 'latest version' URL for the text format. 