### PR TITLE
Point RFC URLs to rfc-editor.org instead of datatracker.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -4,7 +4,7 @@
 
 # Mandatory:
 #   https://pypi.python.org/pypi/xml2rfc
-XML2RFC_RFC_BASE_URL := https://datatracker.ietf.org/doc/html/
+XML2RFC_RFC_BASE_URL := https://www.rfc-editor.org/rfc/
 XML2RFC_ID_BASE_URL := https://datatracker.ietf.org/doc/html/
 XML2RFC_CSS := $(LIBDIR)/v3.css
 xml2rfc ?= xml2rfc -q -s 'Setting consensus="true" for IETF STD document' --rfc-base-url $(XML2RFC_RFC_BASE_URL) --id-base-url $(XML2RFC_ID_BASE_URL)


### PR DESCRIPTION
This reduces the diff between editors' copies and submitted versions.