### PR TITLE
Mark the GITHUB_WORKSPACE as safe

### DIFF
--- a/docker/action/entrypoint.sh
+++ b/docker/action/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
 if [ "$1" = "setup" ]; then
   echo "Running setup"
   exec make -f lib/setup.mk


### PR DESCRIPTION
Today's automated build of this action's containers pulled in the latest version of Git, which includes a fix for CVE-2022-24765. See https://github.blog/2022-04-12-git-security-vulnerability-announced/. As a result, the Github Actions action is failing when it executes git commands inside the container, with the following error message.

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

This PR fixes the issue by running such a command inside the container's entry point script, as recommended here https://github.com/actions/checkout/issues/766.