### PR TITLE
Fix GitHub pages index when using mmark.

### DIFF
--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -127,10 +127,10 @@ these, I set `GOPATH=~/gocode`.
 
 ## Other tools
 
-If you wish to build GitHub Pages, you will also need to install the `toml` Python package:
+If you wish to build GitHub Pages, you will also need to install the Python packages `yaml` (for kramdown-rfc Markdown) and/or `toml` (for mmark Markdown):
 
 ```sh
-$ pip3 install --user toml
+$ pip3 install --user toml yaml
 ```
 
 Some other helpful tools are listed in `config.mk`.

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -96,7 +96,6 @@ on the first line of the file:
 
 * `mmark` files must start with '%%%'
 
-
 ### kramdown-rfc
 
 [`kramdown-rfc`](https://github.com/cabo/kramdown-rfc) requires
@@ -128,8 +127,13 @@ these, I set `GOPATH=~/gocode`.
 
 ## Other tools
 
-Some other helpful tools are listed in `config.mk`.
+If you wish to build GitHub Pages, you will also need to install the `toml` Python package:
 
+```sh
+$ pip3 install --user toml
+```
+
+Some other helpful tools are listed in `config.mk`.
 
 # Update
 

--- a/docker/action/Dockerfile
+++ b/docker/action/Dockerfile
@@ -32,6 +32,7 @@ RUN set -e; \
       py3-requests \
       py3-setuptools \
       py3-six \
+      py3-toml \
       py3-wheel \
       py3-yaml \
       python3 \

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -7,12 +7,23 @@ import sys
 import xml
 import xml.sax
 import yaml
-
+import toml
 
 def extract_md(filename):
     try:
         with open(filename, "r") as fh:
-            return next(yaml.safe_load_all(fh))
+            section_header = fh.readline().strip()
+            if (section_header == r'%%%'):
+                header_data = ""
+                for line in fh:
+                    if line.strip() == r"%%%":
+                        break
+                    header_data += line
+                return toml.loads(header_data)
+            elif (section_header == r'---'):
+                return next(yaml.safe_load_all(fh))
+            else:
+                raise Exception("Unexpected file section header at top of file \"{0}\": expected `\%\%\%` or `---` ".format(section_header))
     except IOError:
         return {}
     except yaml.YAMLError:

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -28,6 +28,8 @@ def extract_md(filename):
         return {}
     except yaml.YAMLError:
         return {}
+    except toml.TomlDecodeError:
+        return {}
 
 
 def extract_xml(filename):


### PR DESCRIPTION
Building of the index.html file for GitHub Pages is broken with the
`mmark` tool due to the metadata being in TOML rather than YAML format.

This results in an index being generated without any extracted metadata.

This change adds the TOML tool and differentiates by the header
characters ('%%%' vs '---') which format to parse.