### PR TITLE
Generated index to use title (instead of abbrev)

### DIFF
--- a/build-index.sh
+++ b/build-index.sh
@@ -194,7 +194,7 @@ function list_dir() {
 
         tr_i
         src=$(ls "$file".{md,xml} 2>/dev/null | head -1)
-        title=$("${libdir}/extract-metadata.py" "$src" abbrev)
+        title=$("${libdir}/extract-metadata.py" "$src" title)
         td "$(a "$(reldot "$dir")/${file}.html" "${title}" html "$file")"
         td "$(a "$(reldot "$dir")/${file}.txt" "plain text" txt "$file")"
         this_githubio=$(githubio "$branch${dir#$root}" "$file")


### PR DESCRIPTION
Use the more descriptive and appropriate full title for the specification in the generated index, rather than the abbreviation.