### PR TITLE
mktemp wants XXXXXX at the end

### DIFF
--- a/build-index.sh
+++ b/build-index.sh
@@ -217,7 +217,8 @@ function list_dir() {
         [[ -n "${src##*:}" ]] || \
             src="origin/${branch}:$(git ls-tree --name-only "origin/$branch" -- "$file".md "$file".xml 2>/dev/null | head -1)"
         if [[ -n "${src##*:}" ]]; then
-            tmp="$(mktemp "/tmp/build-index$$-XXXXXX.${src##*.}")"
+            #tmp="$(mktemp "/tmp/build-index$$-XXXXXX.${src##*.}")"
+            tmp="$(mktemp "/tmp/build-index$$-XXXXXX").${src##*.}"
             tmpfiles+=("$tmp")
             git show "$src" >"$tmp"
             src="$tmp"

--- a/build-index.sh
+++ b/build-index.sh
@@ -217,7 +217,6 @@ function list_dir() {
         [[ -n "${src##*:}" ]] || \
             src="origin/${branch}:$(git ls-tree --name-only "origin/$branch" -- "$file".md "$file".xml 2>/dev/null | head -1)"
         if [[ -n "${src##*:}" ]]; then
-            #tmp="$(mktemp "/tmp/build-index$$-XXXXXX.${src##*.}")"
             tmp="$(mktemp "/tmp/build-index$$-XXXXXX").${src##*.}"
             tmpfiles+=("$tmp")
             git show "$src" >"$tmp"


### PR DESCRIPTION
On my mac, `man 1 mktemp` says:
```
The template may be any file name
with some number of `Xs' appended to it, for example /tmp/temp.XXXX.
```
