### PR TITLE
Stop using symlinks for Gemfile/requirements.txt

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         e=''
         for src in Gemfile requirements.txt; do
-          dst="docker/action/$f"
+          dst="docker/action/$src"
           [ -f "$src" ] || e="$e\n$src is missing"
           [ -f "$dst" ] || e="$e\n$dst is missing"
           diff -u "$dst" "$src" || e="$e\n$src and $dst differ"

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -7,6 +7,11 @@ on:
     - ".github/workflows/template.yml"
     - "template/.github/workflows/**"
     - "v3.css"
+    - "Gemfile"
+    - "action/docker/Gemfile"
+    - "requirements.txt"
+    - "action/docker/requirements.txt"
+
 
 jobs:
   build:
@@ -17,14 +22,27 @@ jobs:
     - name: "Checkout"
       uses: actions/checkout@v2
 
+    - name: "Verify Gemfile and requirements.txt consistency"
+      run: |
+        e=''
+        for src in Gemfile requirements.txt; do
+          dst="docker/action/$f"
+          [ -f "$src" ] || e="$e\n$src is missing"
+          [ -f "$dst" ] || e="$e\n$dst is missing"
+          diff -u "$dst" "$src" || e="$e\n$src and $dst differ"
+        done
+        if [ -n "$e" ]; then
+          ! printf "$e"
+        fi
+
     - name: "Compare workflow files in internet-draft-template"
       run: |
         git clone --depth 1 https://github.com/martinthomson/internet-draft-template idt
         e=''
         for src in template/.github/workflows/*.yml; do
           dst="idt/${src#*/}"
-          [ -f "$dst" ] || e="$e\n$dst is missing"
-          diff -u "$dst" "$src" || e="$e\n$dst is different"
+          [ -f "$dst" ] || e="$e\nworkflow ${src##*/} is missing from internet-draft-template"
+          diff -u "$dst" "$src" || e="$e\nworkflow ${src##*/} differs"
         done
         if [ -n "$e" ]; then
           ! printf "$e"

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,4 @@
-docker/action/Gemfile
+source 'https://rubygems.org'
+
+gem 'kramdown-rfc'
+gem 'net-http-persistent'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,8 @@
-docker/action/requirements.txt
+archive-repo
+iddiff
+pyang
+pyyaml
+rfc-tidy
+svgcheck
+toml
+xml2rfc


### PR DESCRIPTION
This turns out to have some unfortunate effects when updating as the symlink is followed in some cases but not all, especially when constructing the file that is written adjacent to it.

Closes #350.