### PR TITLE
Add plantuml package to GitHub Actions image

### DIFF
--- a/docker/action/Dockerfile
+++ b/docker/action/Dockerfile
@@ -20,6 +20,7 @@ RUN set -e; \
       nodejs \
       npm \
       openssh \
+      plantuml \
       py3-appdirs \
       py3-configargparse \
       py3-html5lib \


### PR DESCRIPTION
Using the template and its GitHub Actions workflows for rendering an Internet Draft, I noticed that it is currently not possible to include figures containing plantUML code, since the [plantuml package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/plantuml) is not included in the Docker image. This PR adds the package to the Dockerfile, which should enable this feature when writing a draft.