### PR TITLE
Use the `deps` target instead of `$(DEPS_FILES)`

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -68,7 +68,7 @@ ifeq (true,$(TIDY))
 MD_POST += | $(trace) $@ -s tidy $(rfc-tidy)
 endif
 
-%.xml: %.md $(DEPS_FILES)
+%.xml: %.md deps
 	@h=$$(head -1 $< | cut -c 1-4 -); set -o pipefail; \
 	if [ "$${h:0:1}" = $$'\ufeff' ]; then echo 'warning: BOM in $<' 1>&2; h="$${h:1:3}"; \
 	else h="$${h:0:3}"; fi; \
@@ -82,7 +82,7 @@ endif
 	  ! echo "Unable to detect '%%%' or '---' in markdown file" 1>&2; \
 	fi && [ -e $@ ]
 
-%.xml: %.org $(DEPS_FILES)
+%.xml: %.org deps
 	$(trace) $@ -s oxtradoc $(oxtradoc) -m outline-to-xml -n "$@" $< | $(xml2rfc) --v2v3 /dev/stdin -o $@
 
 XSLTDIR ?= $(LIBDIR)/rfc2629xslt
@@ -106,15 +106,15 @@ $(XSLTDIR):
 %.html: %.xml $(LIBDIR)/rfc2629.xslt $(LIBDIR)/style.css
 	$(trace) $@ -s xslt-html $(xsltproc) --novalid --stringparam xml2rfc-ext-css-contents "$$(cat $(LIBDIR)/style.css)" $(LIBDIR)/rfc2629.xslt $< > $@
 
-%.txt: %.cleanxml $(DEPS_FILES)
+%.txt: %.cleanxml deps
 	$(trace) $@ -s xml2rfc-txt $(xml2rfc) $< -o $@ --text --no-pagination
 else
-%.html: %.xml $(XML2RFC_CSS) $(DEPS_FILES)
+%.html: %.xml $(XML2RFC_CSS) deps
 	$(trace) $@ -s xml2rfc-html $(xml2rfc) --css=$(XML2RFC_CSS) --metadata-js-url=/dev/null $< -o $@ --html
 # Workaround for https://trac.tools.ietf.org/tools/xml2rfc/trac/ticket/470
 	@-sed -i.rfc-local -e 's,<link[^>]*href=["'"'"]rfc-local.css["'"'"][^>]*>,,' $@; rm -f $@.rfc-local
 
-%.txt: %.xml $(DEPS_FILES)
+%.txt: %.xml deps
 	$(trace) $@ -s xml2rfc-txt $(xml2rfc) $< -o $@ --text --no-pagination
 endif
 


### PR DESCRIPTION
This allows one to add additional deps in the project Makefile using a
double-colon rule, similar to how we do it for `lint`.
