### PR TITLE
Specify svgcheck 0.6.2, as more recent versions seem to break kramdown-rfc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ iddiff
 pyang
 pyyaml
 rfc-tidy
-svgcheck
+svgcheck == 0.6.2
 toml
 xml2rfc


### PR DESCRIPTION
Closes #364
