### PR TITLE
Add chardet to requirements.txt

### DIFF
--- a/docker/action/requirements.txt
+++ b/docker/action/requirements.txt
@@ -1,4 +1,5 @@
 archive-repo
+chardet
 iddiff
 pyang
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 archive-repo
+chardet
 iddiff
 pyang
 pyyaml


### PR DESCRIPTION
This does seem to fix things for me. Otherwise I get this:

```
lib/ghpages.mk:61: target `/tmp/ghpages63687/draft-ietf-dnssd-srp-replication-tmp63664.html' given more than once in the same rule.
lib/ghpages.mk:61: target `/tmp/ghpages63687/draft-ietf-dnssd-srp-replication-tmp63664.txt' given more than once in the same rule.
lib/trace.sh draft-ietf-dnssd-srp-replication-tmp63664.html -s xml2rfc-html /Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/bin/xml2rfc -q -s 'Setting consensus="true" for IETF STD document' --rfc-base-url https://www.rfc-editor.org/rfc/ --id-base-url https://datatracker.ietf.org/doc/html/ --cache=/Users/dschinazi/.cache/xml2rfc --css=lib/v3.css --metadata-js-url=/dev/null draft-ietf-dnssd-srp-replication-tmp63664.xml -o draft-ietf-dnssd-srp-replication-tmp63664.html --html
Traceback (most recent call last):
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/requests/compat.py", line 11, in <module>
    import chardet
ModuleNotFoundError: No module named 'chardet'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/bin/xml2rfc", line 5, in <module>
    from xml2rfc.run import main
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/xml2rfc/__init__.py", line 14, in <module>
    from xml2rfc.parser import  XmlRfcError, CachingResolver, XmlRfcParser, XmlRfc
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/xml2rfc/parser.py", line 13, in <module>
    import requests
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/requests/__init__.py", line 45, in <module>
    from .exceptions import RequestsDependencyWarning
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/requests/exceptions.py", line 9, in <module>
    from .compat import JSONDecodeError as CompatJSONDecodeError
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/requests/compat.py", line 13, in <module>
    import charset_normalizer as chardet
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/charset_normalizer/__init__.py", line 24, in <module>
    from .api import from_bytes, from_fp, from_path
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/charset_normalizer/api.py", line 5, in <module>
    from .cd import (
  File "/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/charset_normalizer/cd.py", line 9, in <module>
    from .md import is_suspiciously_successive_range
ImportError: dlopen(/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/charset_normalizer/md.cpython-39-darwin.so, 0x0002): tried: '/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/charset_normalizer/md.cpython-39-darwin.so' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/charset_normalizer/md.cpython-39-darwin.so' (no such file), '/Users/dschinazi/src/draft-ietf-dnssd-srp-replication/lib/.venv/lib/python3.9/site-packages/charset_normalizer/md.cpython-39-darwin.so' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
make: *** [draft-ietf-dnssd-srp-replication-tmp63664.html] Error 1
```