### PR TITLE
Update Dockerfile to install Chromium for Puppeteer support

### DIFF
--- a/docker/math/Dockerfile
+++ b/docker/math/Dockerfile
@@ -27,4 +27,11 @@ RUN set -e; \
     rm -rf "$tmp"; \
     apk del .locale_build
 
-RUN apk add npm && npm install -g mathjax-node-cli
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ttf-freefont \
+    yarn && \
+    npm install -g mathjax-node-cli


### PR DESCRIPTION
Per #416, adding these deps to the container image to install Chromium and its transient dependencies would facilitate using Puppeteer in GitHub Actions, per the documentation at the address below.

https://pptr.dev/troubleshooting/

The i-d-template maintainer and others recommended mermaid-cli as a viable alternative to aasvg and other tools in #355. The former uses headless Chromium to operate.