### PR TITLE
Fix draft replaces

### DIFF
--- a/upload.mk
+++ b/upload.mk
@@ -32,7 +32,7 @@ endif
 	  file="$$(git ls-files "$${1%-[0-9][0-9]}.*")"; \
 	  for last in $$(git log --follow --name-only --format=format: -- "$${file%-[0-9][0-9]}" | \
 		sed -e '/^$$/d' | grep -v draft-todo-yourname-protocol | cut -f 2 | uniq | tail +2); do \
-	    if [ -n "$$(git tag -l "$${last%.*}")" ]; then \
+	    if [ -n "$$(git tag -l "$${last%.*}-*")" ]; then \
 	      echo -F; echo "replaces=$${last%.*}"; break; \
 	    fi; \
 	  done; \


### PR DESCRIPTION
`git tag -l` takes a pattern as parameter, so if we have a bunch of tags like `draft-me-silly-nonsense-03` and `draft-me-silly-nonsense-42`, then `git tag -l draft-me-silly-nonsense` returns nothing but `git tag -l draft-me-silly-nonsense-*` finds them