### PR TITLE
Fix backupless in-place sed on macOS

### DIFF
--- a/setup-readme.sh
+++ b/setup-readme.sh
@@ -32,6 +32,12 @@ function get_title() {
     echo "${t[*]}"
 }
 
+if [[ "$OSTYPE" =~ (darwin|bsd).* ]] ; then
+  function sed_no_backup() { sed -i '' "$@" ; }
+else
+  function sed_no_backup() { sed -i "$@" ; }
+fi
+
 first=true
 for d in "$@"; do
     fullname="${d%.xml}"
@@ -125,7 +131,7 @@ if [ -n "$wg_all" ]; then
         # /./{x;/\n/{s/.//;p;};x;} prints a blank line before a non-blank line,
         #    but only if the hold buffer has a blank line in it.
         #    The s/.//;p; part ensures that an extra blank line isn't added by deleting one.
-        sed -i -e '/^$/{H;d;};/^## Working Group Info/,$d;/./{x;/\n/{s/.//;p;};x;}' CONTRIBUTING.md
+        sed_no_backup -e '/^$/{H;d;};/^## Working Group Info/,$d;/./{x;/\n/{s/.//;p;};x;}' CONTRIBUTING.md
         cat >>CONTRIBUTING.md <<EOF
 
 

--- a/tests/steps/build_commands.py
+++ b/tests/steps/build_commands.py
@@ -75,11 +75,16 @@ def step_impl(context, target, option):
 
 @when("the draft is broken")
 def step_impl(context):
+    import platform
+    if any(platform.system() == p for p in ['Darwin', 'BSD']):
+        sed_no_backup = ["sed", "-i", ""]
+    else:
+        sed_no_backup = ["sed", "-i"]
     with cd(context.working_dir):
         break_this = glob("draft-*.md")[0]
         run_with_capture(
             context,
-            ["sed", "-i", "-e", "s/TODO Security/{{broken-reference}}/", break_this],
+            sed_no_backup + ["-e", "s/TODO Security/{{broken-reference}}/", break_this],
         )
         context.broken_file = break_this
 

--- a/tests/steps/build_commands.py
+++ b/tests/steps/build_commands.py
@@ -76,7 +76,7 @@ def step_impl(context, target, option):
 @when("the draft is broken")
 def step_impl(context):
     import platform
-    if any(platform.system() == p for p in ['Darwin', 'BSD']):
+    if platform.system() in ['Darwin', 'BSD']:
         sed_no_backup = ["sed", "-i", ""]
     else:
         sed_no_backup = ["sed", "-i"]

--- a/tests/steps/build_commands.py
+++ b/tests/steps/build_commands.py
@@ -76,7 +76,7 @@ def step_impl(context, target, option):
 @when("the draft is broken")
 def step_impl(context):
     import platform
-    if platform.system() in ['Darwin', 'BSD']:
+    if any(p in platform.system() for p in ['Darwin', 'BSD']):
         sed_no_backup = ["sed", "-i", ""]
     else:
         sed_no_backup = ["sed", "-i"]

--- a/update-venue.sh
+++ b/update-venue.sh
@@ -10,6 +10,12 @@ user="$1"
 repo="$2"
 shift 2
 
+if [[ "$OSTYPE" =~ (darwin|bsd).* ]] ; then
+  function sed_no_backup() { sed -i '' "$@" ; }
+else
+  function sed_no_backup() { sed -i "$@" ; }
+fi
+
 last_wg=
 for d in "$@"; do
     if ! head -1 "$d" | grep -q "^---"; then
@@ -20,14 +26,14 @@ for d in "$@"; do
     w="${w#*-}"
     w="${w%%-*}"
 
-    sed -i -e '1,/^---/ {
+    sed_no_backup -e '1,/^---/ {
 /^venue:/,/^[^# ]/{
 s,^[# ]*github: .*,  github: "'"$user/$repo"'",
 s,^[# ]*latest: .*,  latest: "'"https://$user.github.io/$repo/${d%.*}.html"'",
 }
 }' "$d"
     if [[ "$w" == "$last_wg"  ]] || wgmeta "$w"; then
-        sed -i -e '1,/^---/ {
+        sed_no_backup -e '1,/^---/ {
 s,^[# ]*area: .*,area: "'"$wg_area"'",
 s,^[# ]*workgroup: .*,workgroup: "'"$wg_name"'",
 /^venue:/,/^[^# ]/{
@@ -39,7 +45,7 @@ s,^[# ]*arch: .*,  arch: "'"$wg_arch"'",
 }' "$d"
         last_wg="$w"
     else
-	sed -i -e '1,/^---/ {
+	sed_no_backup -e '1,/^---/ {
 s,^[# ]*\(area\|workgroup\):,# \1:,
 /^venue:/,/^[^# ]/{
 s,^[# ]*\(group\|type\|mail\|arch\):,#  \1:,g


### PR DESCRIPTION
Nothing is ever easy, macOS tooling strikes again! I was investigating why `make update-files` kept breaking for me by dumping a random `CONTRIBUTING.md-e` file into my checkout, and tracked it down to yet another disagreement between GNU sed and BSD sed. On both platforms, operating in-place with a backup file works the same way, so commands like `sed -i~ -e 's/foo/bar/' file.txt` or `sed -i.favicon -e 's/foo/bar/' file.txt` work fine. However, in-place usage without a backup file is done differently:
* on GNU/Linux, you can use `-i` or `-i''` or `--in-place`
* on BSD/Darwin, you can use `-i ''`

And of course, there is no invocation that works on both. For more details, see [StackOverflow](https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux).

I've tested the `setup-readme.sh` portion of this change locally and can confirm that it solves the issue.