### PR TITLE
Silence warning on first build

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -1,5 +1,5 @@
 LIBDIR := lib
-include $(LIBDIR)/main.mk
+-include $(LIBDIR)/main.mk
 
 $(LIBDIR)/main.mk:
 ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))


### PR DESCRIPTION
When a draft is built for the first time, it always prints this error log:
```
Makefile:2: lib/main.mk: No such file or directory
```

Switching `include` to `-include` will silence the error, since it is always expected on first launch.