### PR TITLE
Add --allow-local-file-access to xml2rfc common options

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -8,7 +8,7 @@ XML2RFC_ID_BASE_URL := https://datatracker.ietf.org/doc/html/
 
 # Set sensible defaults for different xml2rfc targets.
 # Common options (which are added to $xml2rfc later) so that they can be tweaked further.
-XML2RFC_OPTS := -q --rfc-base-url $(XML2RFC_RFC_BASE_URL) --id-base-url $(XML2RFC_ID_BASE_URL)
+XML2RFC_OPTS := -q --rfc-base-url $(XML2RFC_RFC_BASE_URL) --id-base-url $(XML2RFC_ID_BASE_URL) --allow-local-file-access
 # Target-specific options.
 XML2RFC_TEXT := --text
 ifeq (true,$(TEXT_PAGINATION))


### PR DESCRIPTION
Starting with xml2rfc [v3.27.0](https://github.com/ietf-tools/xml2rfc/releases/tag/v3.27.0), the `--allow-local-file-access` flag is required to include external files using the `src` attribute in `sourcecode` and `artwork`.
Adding `--allow-local-file-access` will minimize issues for existing projects with multiple source files.
