### PR TITLE
Use a more impossible character in sed commands

### DIFF
--- a/update-venue.sh
+++ b/update-venue.sh
@@ -34,13 +34,13 @@ s,^[# ]*latest: .*,  latest: "'"https://$user.github.io/$repo/${d%.*}.html"'",
 }' "$d"
     if [[ "$w" == "$last_wg"  ]] || wgmeta "$w"; then
         sed_no_backup -e '1,/^---/ {
-s,^[# ]*area: .*,area: "'"$wg_area"'",
-s,^[# ]*workgroup: .*,workgroup: "'"$wg_name"'",
+s!^[# ]*area: .*!area: "'"$wg_area"'"!
+s!^[# ]*workgroup: .*!workgroup: "'"$wg_name"'"!
 /^venue:/,/^[^# ]/{
-s,^[# ]*group: .*,  group: "'"$wg_name"'",
-s,^[# ]*type: .*,  type: "'"$wg_type"'",
-s,^[# ]*mail: .*,  mail: "'"$wg_mail"'",
-s,^[# ]*arch: .*,  arch: "'"$wg_arch"'",
+s!^[# ]*group: .*!  group: "'"$wg_name"'"!
+s!^[# ]*type: .*!  type: "'"$wg_type"'"!
+s!^[# ]*mail: .*!  mail: "'"$wg_mail"'"!
+s!^[# ]*arch: .*!  arch: "'"$wg_arch"'"!
 }
 }' "$d"
         last_wg="$w"


### PR DESCRIPTION
The current `update-venue.sh` script [fails if a working group name has a `','` character in it](https://github.com/hpkewg/hpke-pq/actions/runs/14388598227/job/40350006512).  This is the case, for example, in the proposed [HPKE Publication, Kept Efficient (HPKE) WG](https://datatracker.ietf.org/wg/hpke/documents/).  The script fails because the `sed` patterns in it use `,` as the `s///` delimiter.  This PR replaces the `,` delimiter with `!`, in hopes that that is a more impossible character in WG names.  (At least until the formation of the Panic! at the Disco WG)