### PR TITLE
Work around #488

### DIFF
--- a/docker/math/Dockerfile
+++ b/docker/math/Dockerfile
@@ -34,4 +34,4 @@ RUN apk add --no-cache \
     harfbuzz \
     ttf-freefont \
     yarn && \
-    npm install -g mathjax-node-cli
+    npm install -g cabo/mathjax-node-cli


### PR DESCRIPTION
For now, tie `yargs` down to ^17.

(More elaborate fix in:
https://github.com/martinthomson/i-d-template/issues/488#issuecomment-3060764646
)

Of course, needs generation of new docker image.
