### PR TITLE
date -I is not on BSD

### DIFF
--- a/build-targets.sh
+++ b/build-targets.sh
@@ -10,7 +10,7 @@ drafts=("$@")
 candidates=$((${#drafts[@]} * 5))
 versioned="${VERSIONED:-versioned}"
 txt_html_warning="$(mktemp)"
-today="$(date -u -I)"
+today="$(date -u +"%Y-%m-%d")"
 trap 'rm -f "$txt_html_warning"' EXIT
 
 next() {


### PR DESCRIPTION
today= breaks on macOS (and other BSD-based command-lines).