### PR TITLE
Add issues and pull-requests read permissions to archive workflow

### DIFF
--- a/template/.github/workflows/archive.yml
+++ b/template/.github/workflows/archive.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: read
+      pull-requests: read
     steps:
     - name: "Checkout"
       uses: actions/checkout@v6


### PR DESCRIPTION
The GITHUB_TOKEN lacked issues: read and pull-requests: read, causing the archive-repo GraphQL query to return null for private repositories and crash with a TypeError.

The error was

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/lib/python3.12/site-packages/archive-repo/__main__.py", line 9, in <module>
    archive.init(sys.argv[2:])
  File "/usr/lib/python3.12/site-packages/archive-repo/archive.py", line 58, in init
    do_archive(args.repo, args.githubToken, args.refFile, args.outFile, args.issuesOnly)
  File "/usr/lib/python3.12/site-packages/archive-repo/archive.py", line 746, in do_archive
    getIssues(owner, repo, reference)
  File "/usr/lib/python3.12/site-packages/archive-repo/archive.py", line 573, in getIssues
    issues = data["repository"]["issues"]
             ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
make: *** [lib/archive.mk:42: archive.json] Error 1
```