### PR TITLE
Fix gh-pages preview tables rendering as raw Markdown

### DIFF
--- a/build-index.sh
+++ b/build-index.sh
@@ -245,7 +245,6 @@ function list_dir() {
         dir=$(dirname "$file")
         file=$(basename "$file" .txt)
 
-        tr_i
         src="${branch}:$(git ls-tree --name-only "$branch" -- "$file".md "$file".xml 2>/dev/null | head -1)"
         [[ -n "${src##*:}" ]] || \
             src="origin/${branch}:$(git ls-tree --name-only "origin/$branch" -- "$file".md "$file".xml 2>/dev/null | head -1)"
@@ -259,6 +258,7 @@ function list_dir() {
             src=$(ls "$file".{md,xml} 2>/dev/null | head -1)
         fi
         [[ -z "$src" ]] && continue
+        tr_i
         abbrev=$("$python" "${libdir}/extract-metadata.py" "$src" abbrev)
         title=$("$python" "${libdir}/extract-metadata.py" "$src" title)
         td "$(a "$(reldot "$dir")/${file}.html" "$abbrev" "html $file" "$title (HTML)")"

--- a/ghpages.mk
+++ b/ghpages.mk
@@ -109,9 +109,9 @@ endif
 # Clean up obsolete directories
 # Keep old branches for $(GHPAGES_BRANCH_TTL) days after the last changes (on the ${PAGES_BRANCH} branch).
 	@CUTOFF=$$(($$(date '+%s')-($(GHPAGES_BRANCH_TTL)*86400))); \
-	for item in comm -13 \
+	for item in $$(comm -13 \
 	    <(git branch --list --all --format='%(refname:short)' | sort | uniq) \
-	    <(git -C $(GHPAGES_ROOT) ls-tree --name-only -r -d gh-pages | sort | uniq); do \
+	    <(git -C $(GHPAGES_ROOT) ls-tree --name-only -r -d gh-pages | sort | uniq)); do \
 	  if [ -d "$(GHPAGES_ROOT)/$$item" ] && \
 	     [ `git -C $(GHPAGES_ROOT) log -n 1 --format=%ct -- $$item` -lt $$CUTOFF ]; then \
 	    echo "Remove obsolete '$$item'"; \


### PR DESCRIPTION
Fixes two bugs that make stale per-branch preview tables render as literal Markdown (details in #524):

- **`build-index.sh`**: relocate `tr_i` past the `[[ -z "$src" ]] && continue` guard so a draft with no resolvable source emits no row. Previously it left a stray `|` that, for a directory's last entry, swallowed the blank line that terminates the table, causing kramdown to render the block as a paragraph (and SmartyPants to mangle the `---` separators into em/en-dashes).
- **`ghpages.mk`**: add the missing command substitution (`$$(comm …)`) so the obsolete-directory cleanup loop actually runs `comm` instead of iterating its literal arguments. Without it the loop is a no-op and obsolete preview dirs are never pruned.

Verified with kramdown 2.5.2: a two-section sample goes from 1 table + 1 broken paragraph to 2 tables; the cleanup loop goes from removing nothing to correctly listing all obsolete preview dirs.

---
*Diagnosed and authored with Claude Code (Claude Opus 4.8); reviewed and submitted by @mnot.*
